### PR TITLE
[shims] Make retain_n/release_n shims header-only

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,8 +24,7 @@ let package = Package(
     .target(name: "_AtomicsShims"),
     .target(
       name: "Atomics",
-      dependencies: ["_AtomicsShims"],
-      path: "Sources/Atomics"
+      dependencies: ["_AtomicsShims"]
     ),
     .testTarget(
       name: "AtomicsTests",

--- a/Sources/_AtomicsShims/include/_AtomicsShims.h
+++ b/Sources/_AtomicsShims/include/_AtomicsShims.h
@@ -360,12 +360,14 @@ SWIFTATOMIC_DEFINE_TYPE(COMPLEX, DoubleWord, _sa_dword, uint64_t)
 #error "Unsupported intptr_t bit width"
 #endif // __INTPTR_WIDTH
 
-static inline void _sa_retain_n(void *object, uint32_t n) {
+SWIFTATOMIC_INLINE
+void _sa_retain_n(void *object, uint32_t n) {
   extern void *swift_retain_n(void *object, uint32_t n);
   swift_retain_n(object, n);
 }
 
-static inline void _sa_release_n(void *object, uint32_t n) {
+SWIFTATOMIC_INLINE
+void _sa_release_n(void *object, uint32_t n) {
   extern void swift_release_n(void *object, uint32_t n);
   swift_release_n(object, n);
 }

--- a/Sources/_AtomicsShims/include/_AtomicsShims.h
+++ b/Sources/_AtomicsShims/include/_AtomicsShims.h
@@ -360,7 +360,14 @@ SWIFTATOMIC_DEFINE_TYPE(COMPLEX, DoubleWord, _sa_dword, uint64_t)
 #error "Unsupported intptr_t bit width"
 #endif // __INTPTR_WIDTH
 
-extern void _sa_retain_n(void *object, uint32_t n);
-extern void _sa_release_n(void *object, uint32_t n);
+static inline void _sa_retain_n(void *object, uint32_t n) {
+  extern void *swift_retain_n(void *object, uint32_t n);
+  swift_retain_n(object, n);
+}
+
+static inline void _sa_release_n(void *object, uint32_t n) {
+  extern void swift_release_n(void *object, uint32_t n);
+  swift_release_n(object, n);
+}
 
 #endif //SWIFTATOMIC_HEADER_INCLUDED

--- a/Sources/_AtomicsShims/src/_AtomicsShims.c
+++ b/Sources/_AtomicsShims/src/_AtomicsShims.c
@@ -12,12 +12,6 @@
 
 #include "_AtomicsShims.h"
 
-void _sa_retain_n(void *object, uint32_t n) {
-  extern void *swift_retain_n(void *object, uint32_t n);
-  swift_retain_n(object, n);
-}
-
-void _sa_release_n(void *object, uint32_t n) {
-  extern void swift_release_n(void *object, uint32_t n);
-  swift_release_n(object, n);
-}
+// Note: This file intentionally doesn't contain any actual defintions;
+// it only exists to satisfy SPM's requirement that each C target include at
+// least one .c file.


### PR DESCRIPTION
This allows the shims module to be built as a standalone target. Previously the module needed to be linked with the Swift runtime, but this wasn't explicit in the package description, causing build failures in generated Xcode projects.

Resolves issue #8.
