### PR TITLE
Revert "[shims] Make retain_n/release_n shims header-only"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,8 @@ let package = Package(
     .target(name: "_AtomicsShims"),
     .target(
       name: "Atomics",
-      dependencies: ["_AtomicsShims"]
+      dependencies: ["_AtomicsShims"],
+      path: "Sources/Atomics"
     ),
     .testTarget(
       name: "AtomicsTests",

--- a/Sources/_AtomicsShims/include/_AtomicsShims.h
+++ b/Sources/_AtomicsShims/include/_AtomicsShims.h
@@ -360,16 +360,7 @@ SWIFTATOMIC_DEFINE_TYPE(COMPLEX, DoubleWord, _sa_dword, uint64_t)
 #error "Unsupported intptr_t bit width"
 #endif // __INTPTR_WIDTH
 
-SWIFTATOMIC_INLINE
-void _sa_retain_n(void *object, uint32_t n) {
-  extern void *swift_retain_n(void *object, uint32_t n);
-  swift_retain_n(object, n);
-}
-
-SWIFTATOMIC_INLINE
-void _sa_release_n(void *object, uint32_t n) {
-  extern void swift_release_n(void *object, uint32_t n);
-  swift_release_n(object, n);
-}
+extern void _sa_retain_n(void *object, uint32_t n);
+extern void _sa_release_n(void *object, uint32_t n);
 
 #endif //SWIFTATOMIC_HEADER_INCLUDED

--- a/Sources/_AtomicsShims/src/_AtomicsShims.c
+++ b/Sources/_AtomicsShims/src/_AtomicsShims.c
@@ -12,6 +12,12 @@
 
 #include "_AtomicsShims.h"
 
-// Note: This file intentionally doesn't contain any actual defintions;
-// it only exists to satisfy SPM's requirement that each C target include at
-// least one .c file.
+void _sa_retain_n(void *object, uint32_t n) {
+  extern void *swift_retain_n(void *object, uint32_t n);
+  swift_retain_n(object, n);
+}
+
+void _sa_release_n(void *object, uint32_t n) {
+  extern void swift_release_n(void *object, uint32_t n);
+  swift_release_n(object, n);
+}


### PR DESCRIPTION
Reverts apple/swift-atomics#9, as it triggered a compiler issue in Swift 5.3. (https://bugs.swift.org/browse/SR-13708)