### PR TITLE
DoubleWord._readersBitWidth: Switch to using Int.bitWidth

### DIFF
--- a/Sources/Atomics/AtomicStrongReference.swift
+++ b/Sources/Atomics/AtomicStrongReference.swift
@@ -79,11 +79,9 @@ extension DoubleWord {
 
   @inline(__always)
   fileprivate static var _readersBitWidth: Int {
-    #if arch(i386) || arch(arm) || arch(arm64_32)
-    return 8
-    #else
-    return 16
-    #endif
+    // This reserves 8 bits for the accesses-in-flight counter on 32-bit
+    // systems, and 16 bits on 64-bit systems.
+    Int.bitWidth / 4
   }
 
   @inline(__always)


### PR DESCRIPTION
This fixes a spurious warning about `arch(arm64_32)` emitted by swift.org compiler builds.

Replacing the compile-time condition with a straightforward (compile-time evaluable) expression seems like the best approach to deal with platform differences.

The new expression `Int.bitWidth / 4` also documents the intention behind the original constants (8 & 16). (The rest of the bits represent the version number, which seems far more likely to be in danger of cycling back to the original value (triggering ABA issues) than >255 threads all simultaneously accessing the same reference.)

Resolves #19.