### PR TITLE
[manifest] Fix warnings in 5.3 toolchains

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,15 +21,31 @@ let package = Package(
       targets: ["Atomics"]),
   ],
   targets: [
-    .target(name: "_AtomicsShims"),
+    .target(
+      name: "_AtomicsShims",
+      exclude: [
+        "CMakeLists.txt"
+      ]
+    ),
     .target(
       name: "Atomics",
-      dependencies: ["_AtomicsShims"]
+      dependencies: ["_AtomicsShims"],
+      exclude: [
+        "CMakeLists.txt",
+        "HighLevelTypes.swift.gyb",
+        "PointerConformances.swift.gyb",
+        "IntegerConformances.swift.gyb",
+        "AtomicBool.swift.gyb",
+        "AtomicLazyReference.swift.gyb",
+      ]
     ),
     .testTarget(
       name: "AtomicsTests",
       dependencies: ["Atomics"],
-      exclude: ["main.swift"]
+      exclude: [
+        "main.swift",
+        "Basics.swift.gyb"
+      ]
     ),
   ]
 )


### PR DESCRIPTION
Requiring a 5.3 toolchain introduced a number of new warnings, because of the new resource files feature. Explicitly exclude CMake files and .gyb files from package targets.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-atomics)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [X] I've verified that my change does not break any existing tests.
- [ ] I've updated the documentation if necessary.
