### PR TITLE
[shims] Only define atomic shims in Swift's Clang Importer

### DIFF
--- a/Sources/_AtomicsShims/include/_AtomicsShims.h
+++ b/Sources/_AtomicsShims/include/_AtomicsShims.h
@@ -56,8 +56,13 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <stdatomic.h>
 #include <assert.h>
+// The atomic primitives are only needed when this is compiled using Swift's
+// Clang Importer. This allows us to continue reling on some Clang extensions
+// (see https://github.com/apple/swift-atomics/issues/37).
+#if defined(__swift__)
+#  include <stdatomic.h>
+#endif
 
 // For now, assume double-wide atomics are available everywhere,
 // except on Linux/x86_64, where they need to be manually enabled
@@ -72,6 +77,8 @@
 #    define ENABLE_DOUBLEWIDE_ATOMICS 1
 #  endif
 #endif
+
+#if defined(__swift__)
 
 #define SWIFTATOMIC_INLINE static inline __attribute__((__always_inline__))
 #define SWIFTATOMIC_SWIFT_NAME(name) __attribute__((swift_name(#name)))
@@ -347,6 +354,8 @@ SWIFTATOMIC_DEFINE_TYPE(COMPLEX, DoubleWord, _sa_dword, _sa_double_word_ctype)
 #else
 SWIFTATOMIC_STORAGE_TYPE(DoubleWord, _sa_dword, _sa_double_word_ctype)
 #endif
+
+#endif // __swift__
 
 #if ENABLE_DOUBLEWIDE_ATOMICS
 extern void _sa_retain_n(void *object, uint32_t n);


### PR DESCRIPTION
Per #37, we currently happen to use some non-standard C atomics that only work in Clang; to prevent issues when this module gets compiled using other compilers, `#ifdef` out all the actual shims, leaving only the definitions for `retain_n`/`release_n`.

(For example, CMake builds the shims module using the system C compiler by default, which is usually GCC on Linux.)

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-atomics)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [X] I've verified that my change does not break any existing tests.
- [ ] I've updated the documentation if necessary.
