### PR TITLE
implement AtomicStorage for Optionals of RawRepresentable types

### DIFF
--- a/Sources/Atomics/AtomicOptionalRawRepresentable.swift
+++ b/Sources/Atomics/AtomicOptionalRawRepresentable.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Atomics open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -54,8 +54,8 @@ public struct AtomicOptionalRawRepresentableStorage<Wrapped>: AtomicStorage
     at pointer: UnsafeMutablePointer<Self>,
     ordering: AtomicLoadOrdering
   ) -> Optional<Wrapped> {
-    let ro = Storage.atomicLoad(at: _extract(pointer),
-                                     ordering: ordering)
+    let ro = Storage.atomicLoad(
+      at: _extract(pointer), ordering: ordering)
     return ro.flatMap(Wrapped.init(rawValue:))
   }
 
@@ -66,9 +66,8 @@ public struct AtomicOptionalRawRepresentableStorage<Wrapped>: AtomicStorage
     at pointer: UnsafeMutablePointer<Self>,
     ordering: AtomicStoreOrdering
   ) {
-    Storage.atomicStore(desired?.rawValue,
-                        at: _extract(pointer),
-                        ordering: ordering)
+    Storage.atomicStore(
+      desired?.rawValue, at: _extract(pointer), ordering: ordering)
   }
 
   @_semantics("atomics.requires_constant_orderings")
@@ -78,9 +77,8 @@ public struct AtomicOptionalRawRepresentableStorage<Wrapped>: AtomicStorage
     at pointer: UnsafeMutablePointer<Self>,
     ordering: AtomicUpdateOrdering
   ) -> Optional<Wrapped> {
-    let ro = Storage.atomicExchange(desired?.rawValue,
-                                     at: _extract(pointer),
-                                     ordering: ordering)
+    let ro = Storage.atomicExchange(
+      desired?.rawValue, at: _extract(pointer), ordering: ordering)
     return ro.flatMap(Wrapped.init(rawValue:))
   }
 
@@ -92,10 +90,11 @@ public struct AtomicOptionalRawRepresentableStorage<Wrapped>: AtomicStorage
     at pointer: UnsafeMutablePointer<Self>,
     ordering: AtomicUpdateOrdering
   ) -> (exchanged: Bool, original: Optional<Wrapped>) {
-    let ro = Storage.atomicCompareExchange(expected: expected?.rawValue,
-                                           desired: desired?.rawValue,
-                                           at: _extract(pointer),
-                                           ordering: ordering)
+    let ro = Storage.atomicCompareExchange(
+      expected: expected?.rawValue,
+      desired: desired?.rawValue,
+      at: _extract(pointer),
+      ordering: ordering)
     return (ro.exchanged, ro.original.flatMap(Wrapped.init(rawValue:)))
   }
 
@@ -108,11 +107,12 @@ public struct AtomicOptionalRawRepresentableStorage<Wrapped>: AtomicStorage
     successOrdering: AtomicUpdateOrdering,
     failureOrdering: AtomicLoadOrdering
   ) -> (exchanged: Bool, original: Optional<Wrapped>) {
-    let ro = Storage.atomicCompareExchange(expected: expected?.rawValue,
-                                           desired: desired?.rawValue,
-                                           at: _extract(pointer),
-                                           successOrdering: successOrdering,
-                                           failureOrdering: failureOrdering)
+    let ro = Storage.atomicCompareExchange(
+      expected: expected?.rawValue,
+      desired: desired?.rawValue,
+      at: _extract(pointer),
+      successOrdering: successOrdering,
+      failureOrdering: failureOrdering)
     return (ro.exchanged, ro.original.flatMap(Wrapped.init(rawValue:)))
   }
 
@@ -125,11 +125,12 @@ public struct AtomicOptionalRawRepresentableStorage<Wrapped>: AtomicStorage
     successOrdering: AtomicUpdateOrdering,
     failureOrdering: AtomicLoadOrdering
   ) -> (exchanged: Bool, original: Optional<Wrapped>) {
-    let ro = Storage.atomicWeakCompareExchange(expected: expected?.rawValue,
-                                               desired: desired?.rawValue,
-                                               at: _extract(pointer),
-                                               successOrdering: successOrdering,
-                                               failureOrdering: failureOrdering)
+    let ro = Storage.atomicWeakCompareExchange(
+      expected: expected?.rawValue,
+      desired: desired?.rawValue,
+      at: _extract(pointer),
+      successOrdering: successOrdering,
+      failureOrdering: failureOrdering)
     return (ro.exchanged, ro.original.flatMap(Wrapped.init(rawValue:)))
   }
 }

--- a/Sources/Atomics/AtomicOptionalRawRepresentable.swift
+++ b/Sources/Atomics/AtomicOptionalRawRepresentable.swift
@@ -1,0 +1,134 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Atomics open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+extension RawRepresentable where RawValue: AtomicOptionalWrappable {
+  public typealias AtomicOptionalRepresentation = RawValue.AtomicOptionalRepresentation
+}
+
+/// A default atomic storage representation for a `RawRepresentable` type
+/// whose `RawValue` conforms to `AtomicOptionalWrappable`.
+@frozen
+public struct AtomicOptionalRawRepresentableStorage<Wrapped>: AtomicStorage
+  where Wrapped: RawRepresentable,
+        Wrapped.RawValue: AtomicOptionalWrappable {
+
+  public typealias Value = Optional<Wrapped>
+
+  @usableFromInline
+  typealias Storage = Wrapped.RawValue.AtomicOptionalRepresentation
+
+  @usableFromInline
+  var _storage: Storage
+
+  @_transparent @_alwaysEmitIntoClient
+  public init(_ value: __owned Optional<Wrapped>) {
+    _storage = Storage(value?.rawValue)
+  }
+
+  @_transparent @_alwaysEmitIntoClient
+  __consuming public func dispose() -> Optional<Wrapped> {
+    _storage.dispose().flatMap(Wrapped.init(rawValue:))
+  }
+
+  @usableFromInline
+  @_transparent @_alwaysEmitIntoClient
+  static func _extract(
+    _ ptr: UnsafeMutablePointer<Self>
+  ) -> UnsafeMutablePointer<Storage> {
+    return UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: Storage.self)
+  }
+
+  @_semantics("atomics.requires_constant_orderings")
+  @_transparent @_alwaysEmitIntoClient
+  public static func atomicLoad(
+    at pointer: UnsafeMutablePointer<Self>,
+    ordering: AtomicLoadOrdering
+  ) -> Optional<Wrapped> {
+    let ro = Storage.atomicLoad(at: _extract(pointer),
+                                     ordering: ordering)
+    return ro.flatMap(Wrapped.init(rawValue:))
+  }
+
+  @_semantics("atomics.requires_constant_orderings")
+  @_transparent @_alwaysEmitIntoClient
+  public static func atomicStore(
+    _ desired: __owned Optional<Wrapped>,
+    at pointer: UnsafeMutablePointer<Self>,
+    ordering: AtomicStoreOrdering
+  ) {
+    Storage.atomicStore(desired?.rawValue,
+                        at: _extract(pointer),
+                        ordering: ordering)
+  }
+
+  @_semantics("atomics.requires_constant_orderings")
+  @_transparent @_alwaysEmitIntoClient
+  public static func atomicExchange(
+    _ desired: __owned Optional<Wrapped>,
+    at pointer: UnsafeMutablePointer<Self>,
+    ordering: AtomicUpdateOrdering
+  ) -> Optional<Wrapped> {
+    let ro = Storage.atomicExchange(desired?.rawValue,
+                                     at: _extract(pointer),
+                                     ordering: ordering)
+    return ro.flatMap(Wrapped.init(rawValue:))
+  }
+
+  @_semantics("atomics.requires_constant_orderings")
+  @_transparent @_alwaysEmitIntoClient
+  public static func atomicCompareExchange(
+    expected: Optional<Wrapped>,
+    desired: __owned Optional<Wrapped>,
+    at pointer: UnsafeMutablePointer<Self>,
+    ordering: AtomicUpdateOrdering
+  ) -> (exchanged: Bool, original: Optional<Wrapped>) {
+    let ro = Storage.atomicCompareExchange(expected: expected?.rawValue,
+                                           desired: desired?.rawValue,
+                                           at: _extract(pointer),
+                                           ordering: ordering)
+    return (ro.exchanged, ro.original.flatMap(Wrapped.init(rawValue:)))
+  }
+
+  @_semantics("atomics.requires_constant_orderings")
+  @_transparent @_alwaysEmitIntoClient
+  public static func atomicCompareExchange(
+    expected: Optional<Wrapped>,
+    desired: __owned Optional<Wrapped>,
+    at pointer: UnsafeMutablePointer<Self>,
+    successOrdering: AtomicUpdateOrdering,
+    failureOrdering: AtomicLoadOrdering
+  ) -> (exchanged: Bool, original: Optional<Wrapped>) {
+    let ro = Storage.atomicCompareExchange(expected: expected?.rawValue,
+                                           desired: desired?.rawValue,
+                                           at: _extract(pointer),
+                                           successOrdering: successOrdering,
+                                           failureOrdering: failureOrdering)
+    return (ro.exchanged, ro.original.flatMap(Wrapped.init(rawValue:)))
+  }
+
+  @_semantics("atomics.requires_constant_orderings")
+  @_transparent @_alwaysEmitIntoClient
+  public static func atomicWeakCompareExchange(
+    expected: Optional<Wrapped>,
+    desired: __owned Optional<Wrapped>,
+    at pointer: UnsafeMutablePointer<Self>,
+    successOrdering: AtomicUpdateOrdering,
+    failureOrdering: AtomicLoadOrdering
+  ) -> (exchanged: Bool, original: Optional<Wrapped>) {
+    let ro = Storage.atomicWeakCompareExchange(expected: expected?.rawValue,
+                                               desired: desired?.rawValue,
+                                               at: _extract(pointer),
+                                               successOrdering: successOrdering,
+                                               failureOrdering: failureOrdering)
+    return (ro.exchanged, ro.original.flatMap(Wrapped.init(rawValue:)))
+  }
+}

--- a/Sources/Atomics/AtomicOptionalRawRepresentable.swift
+++ b/Sources/Atomics/AtomicOptionalRawRepresentable.swift
@@ -44,6 +44,7 @@ public struct AtomicOptionalRawRepresentableStorage<Wrapped>: AtomicStorage
   static func _extract(
     _ ptr: UnsafeMutablePointer<Self>
   ) -> UnsafeMutablePointer<Storage> {
+    // `Self` is layout-compatible with its only stored property.
     return UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: Storage.self)
   }
 


### PR DESCRIPTION
An example I wrote a while back needs atomics both for a `RawRepresentable` type and its Optional. This particular combination of functionality was missing from the package.

This PR defines an implementation of `AtomicStorage` for this case:
```swift
public struct AtomicOptionalRawRepresentableStorage<Wrapped>: AtomicStorage
  where Wrapped: RawRepresentable,
        Wrapped.RawValue: AtomicOptionalWrappable {
  // ...
}
```

A `RawRepresentable` type can semi-automatically conform to `AtomicOptionalWrappable` by declaring
(via typealias) that its `AtomicOptionalRepresentation` is `AtomicOptionalRawRepresentableStorage<Self>`.

<!-- Thanks for contributing to Swift Atomics! -->

<!-- If this pull request adds new API, please add '?template=new.md'
     to the URL to switch to the appropriate template. -->

<!-- Please add a description of your changes and rationale. Provide
     links to an existing issue or external references/discussions, if
     appropriate. -->
     
<!-- Complete the steps in the checklist by placing an 'x' in each box:
    - [x] I've completed this task
    - [ ] This task isn't completed
-->


### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-atomics)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [x] I've verified that my change does not break any existing tests.
- [x] I've updated the documentation if necessary.
