### PR TITLE
Fix `UnsafeAtomic`'s `Sendable` conformance

### DIFF
--- a/Sources/Atomics/AtomicLazyReference.swift.gyb
+++ b/Sources/Atomics/AtomicLazyReference.swift.gyb
@@ -47,6 +47,11 @@ public struct UnsafeAtomicLazyReference<Instance: AnyObject> {
   }
 }
 
+#if compiler(>=5.5) && canImport(_Concurrency)
+extension UnsafeAtomicLazyReference: @unchecked Sendable
+where Instance: Sendable {}
+#endif
+
 extension UnsafeAtomicLazyReference {
   /// The storage representation for an atomic lazy reference value.
   @frozen

--- a/Sources/Atomics/HighLevelTypes.swift.gyb
+++ b/Sources/Atomics/HighLevelTypes.swift.gyb
@@ -71,6 +71,10 @@ public struct UnsafeAtomic<Value: AtomicValue> {
   }
 }
 
+#if compiler(>=5.5) && canImport(_Concurrency)
+extension UnsafeAtomic: @unchecked Sendable where Value: Sendable {}
+#endif
+
 /// A reference type holding an atomic value, with automatic memory management.
 @_fixed_layout
 public class ManagedAtomic<Value: AtomicValue> {

--- a/Sources/Atomics/autogenerated/AtomicLazyReference.swift
+++ b/Sources/Atomics/autogenerated/AtomicLazyReference.swift
@@ -50,6 +50,11 @@ public struct UnsafeAtomicLazyReference<Instance: AnyObject> {
   }
 }
 
+#if compiler(>=5.5) && canImport(_Concurrency)
+extension UnsafeAtomicLazyReference: @unchecked Sendable
+where Instance: Sendable {}
+#endif
+
 extension UnsafeAtomicLazyReference {
   /// The storage representation for an atomic lazy reference value.
   @frozen

--- a/Sources/Atomics/autogenerated/HighLevelTypes.swift
+++ b/Sources/Atomics/autogenerated/HighLevelTypes.swift
@@ -73,6 +73,10 @@ public struct UnsafeAtomic<Value: AtomicValue> {
   }
 }
 
+#if compiler(>=5.5) && canImport(_Concurrency)
+extension UnsafeAtomic: @unchecked Sendable where Value: Sendable {}
+#endif
+
 /// A reference type holding an atomic value, with automatic memory management.
 @_fixed_layout
 public class ManagedAtomic<Value: AtomicValue> {


### PR DESCRIPTION
In Swift 5.5, `UnsafeAtomic` has gained an implicit, unconditional `Sendable` conformance, because it is a `@frozen public struct` whose sole stored property (an `UnsafeMutablePointer` is also `Sendable`. This is not correct -- we only want `UnsafeAtomic` to conform to `Sendable` if its `Value` does.

Explicitly declare the conformance on 5.5 to disable the bogus inference.

Resolves #47.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-atomics)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [X] I've verified that my change does not break any existing tests.
- [ ] I've updated the documentation if necessary.
