### PR TITLE
Simplify shims

### DIFF
--- a/Sources/Atomics/AtomicStrongReference.swift
+++ b/Sources/Atomics/AtomicStrongReference.swift
@@ -55,14 +55,14 @@ extension DoubleWord {
     let r = UInt(bitPattern: readers) & Self._readersMask
     assert(r == readers)
     self.init(
-      high: r | (UInt(bitPattern: version) &<< Self._readersBitWidth),
-      low: UInt(bitPattern: _raw))
+      first: UInt(bitPattern: _raw),
+      second: r | (UInt(bitPattern: version) &<< Self._readersBitWidth))
   }
 
   @inline(__always)
   fileprivate var _raw: UnsafeMutableRawPointer? {
-    get { UnsafeMutableRawPointer(bitPattern: low) }
-    set { low = UInt(bitPattern: newValue) }
+    get { UnsafeMutableRawPointer(bitPattern: first) }
+    set { first = UInt(bitPattern: newValue) }
   }
 
   @inline(__always)
@@ -83,22 +83,22 @@ extension DoubleWord {
 
   @inline(__always)
   fileprivate var _readers: Int {
-    get { Int(bitPattern: high & Self._readersMask) }
+    get { Int(bitPattern: second & Self._readersMask) }
     set {
       let n = UInt(bitPattern: newValue) & Self._readersMask
       assert(n == newValue)
-      high = (high & ~Self._readersMask) | n
+      second = (second & ~Self._readersMask) | n
     }
   }
 
   @inline(__always)
   fileprivate var _version: Int {
-    get { Int(bitPattern: high &>> Self._readersBitWidth) }
+    get { Int(bitPattern: second &>> Self._readersBitWidth) }
     set {
       // Silently truncate any high bits we cannot store.
-      high = (
+      second = (
         (UInt(bitPattern: newValue) &<< Self._readersBitWidth) |
-        high & Self._readersMask)
+        second & Self._readersMask)
     }
   }
 }

--- a/Sources/Atomics/DoubleWord.swift
+++ b/Sources/Atomics/DoubleWord.swift
@@ -17,101 +17,50 @@ public typealias DoubleWord = _AtomicsShims.DoubleWord
 extension DoubleWord {
   /// Initialize a new `DoubleWord` value given its high- and
   /// low-order words.
+  @available(*, deprecated, renamed: "init(first:second:)")
   @inlinable @inline(__always)
   public init(high: UInt, low: UInt) {
-    self = _sa_dword_create(high, low)
-  }
-
-  /// Initialize a new `DoubleWord` value given its component words,
-  /// in the order in which they are laid out in memory.
-  @inlinable @inline(__always)
-  public init(first: UInt, second: UInt) {
-#if _endian(little)
-    self = _sa_dword_create(second, first)
-#else
-    self = _sa_dword_create(first, second)
-#endif
+    self.init(first: low, second: high)
   }
 
   /// The most significant word in `self`, considering it as a single,
-  /// wide integer value. This may correspond to either `first` or
-  /// `second`, depending on the endianness of the underlying
-  /// architecture.
+  /// wide integer value.
+  @available(*, deprecated, renamed: "second")
   @inlinable @inline(__always)
   public var high: UInt {
-    get { _sa_dword_extract_high(self) }
-    set { self = _sa_dword_create(newValue, low) }
+    get { second }
+    set { second = newValue }
   }
 
   /// The least significant word in `self`, considering it as a
   /// single, wide integer value. This may correspond to either
   /// `first` or `second`, depending on the endianness of the
   /// underlying architecture.
+  @available(*, deprecated, renamed: "first")
   @inlinable @inline(__always)
   public var low: UInt {
-    get { _sa_dword_extract_low(self) }
-    set { self = _sa_dword_create(high, newValue) }
-  }
-
-
-  /// The first word in `self` in its underlying binary
-  /// representation.
-  @inlinable @inline(__always)
-  public var first: UInt {
-    get {
-        #if _endian(little)
-        return _sa_dword_extract_low(self)
-        #else
-        return _sa_dword_extract_high(self)
-        #endif
-    }
-    set {
-        #if _endian(little)
-        self = _sa_dword_create(high, newValue)
-        #else
-        self = _sa_dword_create(newValue, low)
-        #endif
-    }
-  }
-
-  /// The second word in `self` in its underlying binary
-  /// representation.
-  @inlinable @inline(__always)
-  public var second: UInt {
-    get {
-        #if _endian(little)
-        return _sa_dword_extract_high(self)
-        #else
-        return _sa_dword_extract_low(self)
-        #endif
-    }
-    set {
-        #if _endian(little)
-        self = _sa_dword_create(newValue, low)
-        #else
-        self = _sa_dword_create(high, newValue)
-        #endif
-    }
+    get { first }
+    set { first = newValue }
   }
 }
 
 extension DoubleWord: Equatable {
   @inlinable
   public static func ==(left: Self, right: Self) -> Bool {
-    left.high == right.high && left.low == right.low
+    left.first == right.first && left.second == right.second
   }
 }
 
 extension DoubleWord: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {
-    hasher.combine(self.high)
-    hasher.combine(self.low)
+    hasher.combine(self.first)
+    hasher.combine(self.second)
   }
 }
 
 extension DoubleWord: CustomStringConvertible {
   public var description: String {
-    "DoubleWord(high: \(high), low: \(low))"
+    "DoubleWord(first: \(first), second: \(second))"
   }
 }

--- a/Sources/_AtomicsShims/include/_AtomicsShims.h
+++ b/Sources/_AtomicsShims/include/_AtomicsShims.h
@@ -24,34 +24,8 @@
 // write/maintain a thousand or so functions, we use the C preprocessor to stamp
 // these out.
 //
-// Supporting double-wide integers is tricky, because neither Swift nor C has
-// standard integer representations for these on platforms where `Int` has a bit
-// width of 64. Standard C can model 128-bit atomics through `_Atomic(struct
-// pair)` where `pair` is a struct of two `intptr_t`s, but current Swift
-// compilers (as of version 5.3) get confused by atomic structs
-// (https://reviews.llvm.org/D86218). To work around that, we need to use the
-// nonstandard `__uint128_t` type. The Swift compiler does seem to be able to
-// deal with `_Atomic(__uint128_t)`, but it refuses to directly import
-// `__uint128_t`, so that too needs to be wrapped in a dummy struct (which we
-// call `_sa_dword`). We want to stamp out 128-bit atomics from the same code as
-// regular atomics, so this requires all atomic operations to distinguish
-// between the "exported" C type and the corresponding "internal"
-// representation, and to explicitly convert between them as needed. This is
-// done using the `SWIFTATOMIC_ENCODE_<swiftType>` and
-// `SWIFTATOMIC_DECODE_<swiftType>` family of macros.
-//
-// In the case of compare-and-exchange, the conversion of the `expected`
-// argument needs to go through a temporary stack variable that would result in
-// slightly worse codegen for the regular single-word case, so we distinguish
-// between `SIMPLE` and `COMPLEX` cmpxchg variants. The single variant assumes
-// that the internal representation is identical to the exported type, and does
-// away with the comparisons.
-//
 // FIXME: Upgrading from the preprocessor to gyb would perhaps make things more
 // readable here.
-//
-// FIXME: Eliminate the encoding/decoding mechanism once the package requires a
-// compiler that includes https://reviews.llvm.org/D86218.
 
 
 #include <stdbool.h>
@@ -65,6 +39,7 @@
 
 #define SWIFTATOMIC_INLINE static inline __attribute__((__always_inline__))
 #define SWIFTATOMIC_SWIFT_NAME(name) __attribute__((swift_name(#name)))
+#define SWIFTATOMIC_ALIGNED(alignment) __attribute__((aligned(alignment)))
 
 // Atomic fences
 #define SWIFTATOMIC_THREAD_FENCE_FN(order)                              \
@@ -79,69 +54,62 @@ SWIFTATOMIC_THREAD_FENCE_FN(acq_rel)
 SWIFTATOMIC_THREAD_FENCE_FN(seq_cst)
 
 // Definition of an atomic storage type.
-#define SWIFTATOMIC_STORAGE_TYPE(swiftType, cType, storageType)         \
+#define SWIFTATOMIC_STORAGE_TYPE(swiftType, cType)                      \
   typedef struct {                                                      \
-    _Atomic(storageType) value;                                         \
+    _Atomic(cType) value;                                               \
   } _sa_##swiftType                                                     \
   SWIFTATOMIC_SWIFT_NAME(_Atomic##swiftType##Storage);
 
 // Storage value initializer
-#define SWIFTATOMIC_PREPARE_FN(swiftType, cType, storageType)           \
+#define SWIFTATOMIC_PREPARE_FN(swiftType, cType)                        \
   SWIFTATOMIC_INLINE                                                    \
   _sa_##swiftType _sa_prepare_##swiftType(cType value)                  \
   {                                                                     \
-    _sa_##swiftType storage = { SWIFTATOMIC_ENCODE_##swiftType(value) }; \
+    _sa_##swiftType storage = { value };                                \
     assert(atomic_is_lock_free(&storage.value));                        \
     return storage;                                                     \
   }
 
 // Storage value disposal function
-#define SWIFTATOMIC_DISPOSE_FN(swiftType, cType, storageType)           \
+#define SWIFTATOMIC_DISPOSE_FN(swiftType, cType)                        \
   SWIFTATOMIC_INLINE                                                    \
   cType _sa_dispose_##swiftType(_sa_##swiftType storage)                \
   {                                                                     \
-    return SWIFTATOMIC_DECODE_##swiftType(storage.value);               \
+    return storage.value;                                               \
   }
 
 // Atomic load
-#define SWIFTATOMIC_LOAD_FN(swiftType, cType, storageType, order)       \
+#define SWIFTATOMIC_LOAD_FN(swiftType, cType, order)                    \
   SWIFTATOMIC_INLINE                                                    \
-  cType _sa_load_##order##_##swiftType(                                 \
-    _sa_##swiftType *ptr)                                               \
+  cType _sa_load_##order##_##swiftType(_sa_##swiftType *ptr)            \
   {                                                                     \
-    return SWIFTATOMIC_DECODE_##swiftType(                              \
-      atomic_load_explicit(&ptr->value,                                 \
-                           memory_order_##order));                      \
+    return atomic_load_explicit(&ptr->value, memory_order_##order);     \
   }
 
 // Atomic store
-#define SWIFTATOMIC_STORE_FN(swiftType, cType, storageType, order)      \
+#define SWIFTATOMIC_STORE_FN(swiftType, cType, order)                   \
   SWIFTATOMIC_INLINE                                                    \
   void _sa_store_##order##_##swiftType(                                 \
     _sa_##swiftType *ptr,                                               \
     cType desired)                                                      \
   {                                                                     \
-    atomic_store_explicit(&ptr->value,                                  \
-                          SWIFTATOMIC_ENCODE_##swiftType(desired),      \
-                          memory_order_##order);                        \
+    atomic_store_explicit(                                              \
+      &ptr->value, desired, memory_order_##order);                      \
   }
 
 // Atomic exchange
-#define SWIFTATOMIC_EXCHANGE_FN(swiftType, cType, storageType, order)   \
+#define SWIFTATOMIC_EXCHANGE_FN(swiftType, cType, order)                \
   SWIFTATOMIC_INLINE                                                    \
   cType _sa_exchange_##order##_##swiftType(                             \
     _sa_##swiftType *ptr,                                               \
     cType desired)                                                      \
   {                                                                     \
-    return SWIFTATOMIC_DECODE_##swiftType(                              \
-      atomic_exchange_explicit(                                         \
-        &ptr->value,                                                    \
-        SWIFTATOMIC_ENCODE_##swiftType(desired),                        \
-        memory_order_##order));                                         \
+    return atomic_exchange_explicit(                                    \
+      &ptr->value, desired, memory_order_##order);                      \
   }
 
 // Atomic compare/exchange
-#define SWIFTATOMIC_CMPXCHG_FN_SIMPLE(_kind, swiftType, cType, storageType, succ, fail) \
+#define SWIFTATOMIC_CMPXCHG_FN(_kind, swiftType, cType, succ, fail)     \
   SWIFTATOMIC_INLINE                                                    \
   bool                                                                  \
   _sa_cmpxchg_##_kind##_##succ##_##fail##_##swiftType(                  \
@@ -157,182 +125,108 @@ SWIFTATOMIC_THREAD_FENCE_FN(seq_cst)
       memory_order_##fail);                                             \
   }
 
-#define SWIFTATOMIC_CMPXCHG_FN_COMPLEX(_kind, swiftType, cType, storageType, succ, fail) \
-  SWIFTATOMIC_INLINE                                                    \
-  bool                                                                  \
-  _sa_cmpxchg_##_kind##_##succ##_##fail##_##swiftType(                  \
-    _sa_##swiftType *ptr,                                               \
-    cType *expected,                                                    \
-    cType desired)                                                      \
-  {                                                                     \
-    storageType _expected = SWIFTATOMIC_ENCODE_##swiftType(*expected);  \
-    bool result = atomic_compare_exchange_##_kind##_explicit(           \
-        &ptr->value,                                                    \
-        &_expected,                                                     \
-        SWIFTATOMIC_ENCODE_##swiftType(desired),                        \
-        memory_order_##succ,                                            \
-        memory_order_##fail);                                           \
-    *expected = SWIFTATOMIC_DECODE_##swiftType(_expected);              \
-    return result;                                                      \
-  }
-
 // Atomic integer operations
-#define SWIFTATOMIC_INTEGER_FN(op, swiftType, cType, storageType, order) \
+#define SWIFTATOMIC_INTEGER_FN(op, swiftType, cType, order)             \
   SWIFTATOMIC_INLINE                                                    \
   cType _sa_fetch_##op##_##order##_##swiftType(                         \
     _sa_##swiftType *ptr,                                               \
     cType operand)                                                      \
   {                                                                     \
-    return SWIFTATOMIC_DECODE_##swiftType(                              \
-      atomic_fetch_##op##_explicit(                                     \
-        &ptr->value,                                                    \
-        SWIFTATOMIC_ENCODE_##swiftType(operand),                        \
-        memory_order_##order));                                         \
-    }
+    return atomic_fetch_##op##_explicit(                                \
+      &ptr->value, operand, memory_order_##order);                      \
+  }
 
 // Functions for each supported operation + memory ordering combination
-#define SWIFTATOMIC_STORE_FNS(swiftType, cType, storageType)           \
-  SWIFTATOMIC_STORE_FN(swiftType, cType, storageType, relaxed)         \
-  SWIFTATOMIC_STORE_FN(swiftType, cType, storageType, release)         \
-  SWIFTATOMIC_STORE_FN(swiftType, cType, storageType, seq_cst)
+#define SWIFTATOMIC_STORE_FNS(swiftType, cType)                         \
+  SWIFTATOMIC_STORE_FN(swiftType, cType, relaxed)                       \
+  SWIFTATOMIC_STORE_FN(swiftType, cType, release)                       \
+  SWIFTATOMIC_STORE_FN(swiftType, cType, seq_cst)
 
-#define SWIFTATOMIC_LOAD_FNS(swiftType, cType, storageType)            \
-  SWIFTATOMIC_LOAD_FN(swiftType, cType, storageType, relaxed)          \
-  SWIFTATOMIC_LOAD_FN(swiftType, cType, storageType, acquire)          \
-  SWIFTATOMIC_LOAD_FN(swiftType, cType, storageType, seq_cst)
+#define SWIFTATOMIC_LOAD_FNS(swiftType, cType)                          \
+  SWIFTATOMIC_LOAD_FN(swiftType, cType, relaxed)                        \
+  SWIFTATOMIC_LOAD_FN(swiftType, cType, acquire)                        \
+  SWIFTATOMIC_LOAD_FN(swiftType, cType, seq_cst)
 
-#define SWIFTATOMIC_EXCHANGE_FNS(swiftType, cType, storageType)        \
-  SWIFTATOMIC_EXCHANGE_FN(swiftType, cType, storageType, relaxed)      \
-  SWIFTATOMIC_EXCHANGE_FN(swiftType, cType, storageType, acquire)      \
-  SWIFTATOMIC_EXCHANGE_FN(swiftType, cType, storageType, release)      \
-  SWIFTATOMIC_EXCHANGE_FN(swiftType, cType, storageType, acq_rel)      \
-  SWIFTATOMIC_EXCHANGE_FN(swiftType, cType, storageType, seq_cst)
+#define SWIFTATOMIC_EXCHANGE_FNS(swiftType, cType)                      \
+  SWIFTATOMIC_EXCHANGE_FN(swiftType, cType, relaxed)                    \
+  SWIFTATOMIC_EXCHANGE_FN(swiftType, cType, acquire)                    \
+  SWIFTATOMIC_EXCHANGE_FN(swiftType, cType, release)                    \
+  SWIFTATOMIC_EXCHANGE_FN(swiftType, cType, acq_rel)                    \
+  SWIFTATOMIC_EXCHANGE_FN(swiftType, cType, seq_cst)
 
-#define SWIFTATOMIC_CMPXCHG_FNS(variant, kind, swiftType, cType, storageType) \
-  SWIFTATOMIC_CMPXCHG_FN_##variant(kind, swiftType, cType, storageType, relaxed, relaxed) \
-  SWIFTATOMIC_CMPXCHG_FN_##variant(kind, swiftType, cType, storageType, acquire, relaxed) \
-  SWIFTATOMIC_CMPXCHG_FN_##variant(kind, swiftType, cType, storageType, release, relaxed) \
-  SWIFTATOMIC_CMPXCHG_FN_##variant(kind, swiftType, cType, storageType, acq_rel, relaxed) \
-  SWIFTATOMIC_CMPXCHG_FN_##variant(kind, swiftType, cType, storageType, seq_cst, relaxed) \
-  SWIFTATOMIC_CMPXCHG_FN_##variant(kind, swiftType, cType, storageType, acquire, acquire) \
-  SWIFTATOMIC_CMPXCHG_FN_##variant(kind, swiftType, cType, storageType, acq_rel, acquire) \
-  SWIFTATOMIC_CMPXCHG_FN_##variant(kind, swiftType, cType, storageType, seq_cst, acquire) \
-  SWIFTATOMIC_CMPXCHG_FN_##variant(kind, swiftType, cType, storageType, seq_cst, seq_cst)
+#define SWIFTATOMIC_CMPXCHG_FNS(kind, swiftType, cType)                 \
+  SWIFTATOMIC_CMPXCHG_FN(kind, swiftType, cType, relaxed, relaxed)      \
+  SWIFTATOMIC_CMPXCHG_FN(kind, swiftType, cType, acquire, relaxed)      \
+  SWIFTATOMIC_CMPXCHG_FN(kind, swiftType, cType, release, relaxed)      \
+  SWIFTATOMIC_CMPXCHG_FN(kind, swiftType, cType, acq_rel, relaxed)      \
+  SWIFTATOMIC_CMPXCHG_FN(kind, swiftType, cType, seq_cst, relaxed)      \
+  SWIFTATOMIC_CMPXCHG_FN(kind, swiftType, cType, acquire, acquire)      \
+  SWIFTATOMIC_CMPXCHG_FN(kind, swiftType, cType, acq_rel, acquire)      \
+  SWIFTATOMIC_CMPXCHG_FN(kind, swiftType, cType, seq_cst, acquire)      \
+  SWIFTATOMIC_CMPXCHG_FN(kind, swiftType, cType, seq_cst, seq_cst)
 
-#define SWIFTATOMIC_INTEGER_FNS(op, swiftType, cType, storageType)     \
-  SWIFTATOMIC_INTEGER_FN(op, swiftType, cType, storageType, relaxed)   \
-  SWIFTATOMIC_INTEGER_FN(op, swiftType, cType, storageType, acquire)   \
-  SWIFTATOMIC_INTEGER_FN(op, swiftType, cType, storageType, release)   \
-  SWIFTATOMIC_INTEGER_FN(op, swiftType, cType, storageType, acq_rel)   \
-  SWIFTATOMIC_INTEGER_FN(op, swiftType, cType, storageType, seq_cst)
+#define SWIFTATOMIC_INTEGER_FNS(op, swiftType, cType)                  \
+  SWIFTATOMIC_INTEGER_FN(op, swiftType, cType, relaxed)                \
+  SWIFTATOMIC_INTEGER_FN(op, swiftType, cType, acquire)                \
+  SWIFTATOMIC_INTEGER_FN(op, swiftType, cType, release)                \
+  SWIFTATOMIC_INTEGER_FN(op, swiftType, cType, acq_rel)                \
+  SWIFTATOMIC_INTEGER_FN(op, swiftType, cType, seq_cst)
 
-#define SWIFTATOMIC_DEFINE_TYPE(variant, swiftType, cType, storageType) \
-  SWIFTATOMIC_STORAGE_TYPE(swiftType, cType, storageType)              \
-  SWIFTATOMIC_PREPARE_FN(swiftType, cType, storageType)                \
-  SWIFTATOMIC_DISPOSE_FN(swiftType, cType, storageType)                \
-  SWIFTATOMIC_LOAD_FNS(swiftType, cType, storageType)                  \
-  SWIFTATOMIC_STORE_FNS(swiftType, cType, storageType)                 \
-  SWIFTATOMIC_EXCHANGE_FNS(swiftType, cType, storageType)              \
-  SWIFTATOMIC_CMPXCHG_FNS(variant, strong, swiftType, cType, storageType) \
-  SWIFTATOMIC_CMPXCHG_FNS(variant, weak, swiftType, cType, storageType)
+#define SWIFTATOMIC_DEFINE_TYPE(swiftType, cType)                      \
+  SWIFTATOMIC_STORAGE_TYPE(swiftType, cType)                           \
+  SWIFTATOMIC_PREPARE_FN(swiftType, cType)                             \
+  SWIFTATOMIC_DISPOSE_FN(swiftType, cType)                             \
+  SWIFTATOMIC_LOAD_FNS(swiftType, cType)                               \
+  SWIFTATOMIC_STORE_FNS(swiftType, cType)                              \
+  SWIFTATOMIC_EXCHANGE_FNS(swiftType, cType)                           \
+  SWIFTATOMIC_CMPXCHG_FNS(strong, swiftType, cType)                    \
+  SWIFTATOMIC_CMPXCHG_FNS(weak, swiftType, cType)
 
-#define SWIFTATOMIC_DEFINE_INTEGER_TYPE(variant, swiftType, cType, storageType) \
-  SWIFTATOMIC_DEFINE_TYPE(variant, swiftType, cType, storageType)      \
-  SWIFTATOMIC_INTEGER_FNS(add, swiftType, cType, storageType)          \
-  SWIFTATOMIC_INTEGER_FNS(sub, swiftType, cType, storageType)          \
-  SWIFTATOMIC_INTEGER_FNS(or, swiftType, cType, storageType)           \
-  SWIFTATOMIC_INTEGER_FNS(xor, swiftType, cType, storageType)          \
-  SWIFTATOMIC_INTEGER_FNS(and, swiftType, cType, storageType)
+#define SWIFTATOMIC_DEFINE_INTEGER_TYPE(swiftType, cType)              \
+  SWIFTATOMIC_DEFINE_TYPE(swiftType, cType)                            \
+  SWIFTATOMIC_INTEGER_FNS(add, swiftType, cType)                       \
+  SWIFTATOMIC_INTEGER_FNS(sub, swiftType, cType)                       \
+  SWIFTATOMIC_INTEGER_FNS(or, swiftType, cType)                        \
+  SWIFTATOMIC_INTEGER_FNS(xor, swiftType, cType)                       \
+  SWIFTATOMIC_INTEGER_FNS(and, swiftType, cType)
 
 // All known integer types
-#define SWIFTATOMIC_ENCODE_Int(value) (value)
-#define SWIFTATOMIC_DECODE_Int(value) (value)
-SWIFTATOMIC_DEFINE_INTEGER_TYPE(SIMPLE, Int, intptr_t, intptr_t)
-
-#define SWIFTATOMIC_ENCODE_Int8(value) (value)
-#define SWIFTATOMIC_DECODE_Int8(value) (value)
-SWIFTATOMIC_DEFINE_INTEGER_TYPE(SIMPLE, Int8, int8_t, int8_t)
-
-#define SWIFTATOMIC_ENCODE_Int16(value) (value)
-#define SWIFTATOMIC_DECODE_Int16(value) (value)
-SWIFTATOMIC_DEFINE_INTEGER_TYPE(SIMPLE, Int16, int16_t, int16_t)
-
-#define SWIFTATOMIC_ENCODE_Int32(value) (value)
-#define SWIFTATOMIC_DECODE_Int32(value) (value)
-SWIFTATOMIC_DEFINE_INTEGER_TYPE(SIMPLE, Int32, int32_t, int32_t)
-
-#define SWIFTATOMIC_ENCODE_Int64(value) (value)
-#define SWIFTATOMIC_DECODE_Int64(value) (value)
-SWIFTATOMIC_DEFINE_INTEGER_TYPE(SIMPLE, Int64, int64_t, int64_t)
-
-#define SWIFTATOMIC_ENCODE_UInt(value) (value)
-#define SWIFTATOMIC_DECODE_UInt(value) (value)
-SWIFTATOMIC_DEFINE_INTEGER_TYPE(SIMPLE, UInt, uintptr_t, uintptr_t)
-
-#define SWIFTATOMIC_ENCODE_UInt8(value) (value)
-#define SWIFTATOMIC_DECODE_UInt8(value) (value)
-SWIFTATOMIC_DEFINE_INTEGER_TYPE(SIMPLE, UInt8, uint8_t, uint8_t)
-
-#define SWIFTATOMIC_ENCODE_UInt16(value) (value)
-#define SWIFTATOMIC_DECODE_UInt16(value) (value)
-SWIFTATOMIC_DEFINE_INTEGER_TYPE(SIMPLE, UInt16, uint16_t, uint16_t)
-
-#define SWIFTATOMIC_ENCODE_UInt32(value) (value)
-#define SWIFTATOMIC_DECODE_UInt32(value) (value)
-SWIFTATOMIC_DEFINE_INTEGER_TYPE(SIMPLE, UInt32, uint32_t, uint32_t)
-
-#define SWIFTATOMIC_ENCODE_UInt64(value) (value)
-#define SWIFTATOMIC_DECODE_UInt64(value) (value)
-SWIFTATOMIC_DEFINE_INTEGER_TYPE(SIMPLE, UInt64, uint64_t, uint64_t)
+SWIFTATOMIC_DEFINE_INTEGER_TYPE(Int, intptr_t)
+SWIFTATOMIC_DEFINE_INTEGER_TYPE(Int8, int8_t)
+SWIFTATOMIC_DEFINE_INTEGER_TYPE(Int16, int16_t)
+SWIFTATOMIC_DEFINE_INTEGER_TYPE(Int32, int32_t)
+SWIFTATOMIC_DEFINE_INTEGER_TYPE(Int64, int64_t)
+SWIFTATOMIC_DEFINE_INTEGER_TYPE(UInt, uintptr_t)
+SWIFTATOMIC_DEFINE_INTEGER_TYPE(UInt8, uint8_t)
+SWIFTATOMIC_DEFINE_INTEGER_TYPE(UInt16, uint16_t)
+SWIFTATOMIC_DEFINE_INTEGER_TYPE(UInt32, uint32_t)
+SWIFTATOMIC_DEFINE_INTEGER_TYPE(UInt64, uint64_t)
 
 // Atomic boolean
 #define SWIFTATOMIC_ENCODE_Bool(value) (value)
 #define SWIFTATOMIC_DECODE_Bool(value) (value)
-SWIFTATOMIC_DEFINE_TYPE(SIMPLE, Bool, bool, bool)
-SWIFTATOMIC_INTEGER_FNS(or, Bool, bool, bool)
-SWIFTATOMIC_INTEGER_FNS(xor, Bool, bool, bool)
-SWIFTATOMIC_INTEGER_FNS(and, Bool, bool, bool)
+SWIFTATOMIC_DEFINE_TYPE(Bool, bool)
+SWIFTATOMIC_INTEGER_FNS(or, Bool, bool)
+SWIFTATOMIC_INTEGER_FNS(xor, Bool, bool)
+SWIFTATOMIC_INTEGER_FNS(and, Bool, bool)
 
-// Double wide atomics (__uint128_t on 64-bit platforms, uint64_t elsewhere)
+// Double wide atomics
 
 #if __SIZEOF_POINTER__ == 8
-# if !defined(__SIZEOF_INT128__)
-#   error "Double wide atomics need __uint128_t"
-# endif
-# define _sa_double_word_ctype __uint128_t
+# define SWIFTATOMIC_DWORD_ALIGNMENT SWIFTATOMIC_ALIGNED(16)
 #elif __SIZEOF_POINTER__ == 4
-# define _sa_double_word_ctype uint64_t
+# define SWIFTATOMIC_DWORD_ALIGNMENT SWIFTATOMIC_ALIGNED(8)
 #else
 # error "Unsupported Pointer Size"
 #endif
 
-typedef struct {
-  _sa_double_word_ctype value;
-} _sa_dword SWIFTATOMIC_SWIFT_NAME(DoubleWord);
+struct _sa_dword {
+  uintptr_t first;
+  uintptr_t second;
+} SWIFTATOMIC_DWORD_ALIGNMENT SWIFTATOMIC_SWIFT_NAME(DoubleWord);
+typedef struct _sa_dword _sa_dword;
 
-SWIFTATOMIC_INLINE
-_sa_dword _sa_dword_create(uintptr_t high, uintptr_t low) {
-  return (_sa_dword){ ((_sa_double_word_ctype)high << __INTPTR_WIDTH__) | (_sa_double_word_ctype)low };
-}
-
-SWIFTATOMIC_INLINE
-uintptr_t _sa_dword_extract_high(_sa_dword value) {
-  return (uintptr_t)(value.value >> __INTPTR_WIDTH__);
-}
-
-SWIFTATOMIC_INLINE
-uintptr_t _sa_dword_extract_low(_sa_dword value) {
-  return (uintptr_t)value.value;
-}
-
-SWIFTATOMIC_INLINE
-_sa_dword _sa_decode_dword(_sa_double_word_ctype value) {
-  return (_sa_dword){ value };
-}
-
-#define SWIFTATOMIC_ENCODE_DoubleWord(_value) (_value).value
-#define SWIFTATOMIC_DECODE_DoubleWord(_value) _sa_decode_dword(_value)
-SWIFTATOMIC_DEFINE_TYPE(COMPLEX, DoubleWord, _sa_dword, _sa_double_word_ctype)
+SWIFTATOMIC_DEFINE_TYPE(DoubleWord, _sa_dword)
 
 #endif // __swift__
 

--- a/Sources/_AtomicsShims/include/_AtomicsShims.h
+++ b/Sources/_AtomicsShims/include/_AtomicsShims.h
@@ -203,8 +203,6 @@ SWIFTATOMIC_DEFINE_INTEGER_TYPE(UInt32, uint32_t)
 SWIFTATOMIC_DEFINE_INTEGER_TYPE(UInt64, uint64_t)
 
 // Atomic boolean
-#define SWIFTATOMIC_ENCODE_Bool(value) (value)
-#define SWIFTATOMIC_DECODE_Bool(value) (value)
 SWIFTATOMIC_DEFINE_TYPE(Bool, bool)
 SWIFTATOMIC_INTEGER_FNS(or, Bool, bool)
 SWIFTATOMIC_INTEGER_FNS(xor, Bool, bool)

--- a/Tests/AtomicsTests/Basics/BasicAtomicDoubleWordTests.swift.gyb
+++ b/Tests/AtomicsTests/Basics/BasicAtomicDoubleWordTests.swift.gyb
@@ -14,8 +14,8 @@
   from gyb import expand
 
   types = [
-    # Label        Type          a                                 b
-    ("DoubleWord", "DoubleWord", "DoubleWord(high: 100, low: 64)", "DoubleWord(high: 50, low: 32)"),
+    # Label        Type          a                                     b
+    ("DoubleWord", "DoubleWord", "DoubleWord(first: 100, second: 64)", "DoubleWord(first: 50, second: 32)"),
   ]
 }%
 ${expand("BasicTests.gyb-template", line_directive='', types=types)}

--- a/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicDoubleWordTests.swift
+++ b/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicDoubleWordTests.swift
@@ -26,1568 +26,1568 @@ import Atomics
 class BasicAtomicDoubleWordTests: XCTestCase {
 
   func test_create_destroy() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
-    let w: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 50, low: 32))
+    let w: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 50, second: 32))
     defer { w.destroy() }
-    XCTAssertEqual(w.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(w.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
   }
 
   func test_load_relaxed() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
-    let w: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 50, low: 32))
+    let w: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 50, second: 32))
     defer { w.destroy() }
-    XCTAssertEqual(w.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(w.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
   }
 
   func test_load_acquiring() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
-    XCTAssertEqual(v.load(ordering: .acquiring), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(v.load(ordering: .acquiring), DoubleWord(first: 100, second: 64))
 
-    let w: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 50, low: 32))
+    let w: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 50, second: 32))
     defer { w.destroy() }
-    XCTAssertEqual(w.load(ordering: .acquiring), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(w.load(ordering: .acquiring), DoubleWord(first: 50, second: 32))
   }
 
   func test_load_sequentiallyConsistent() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
-    XCTAssertEqual(v.load(ordering: .sequentiallyConsistent), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(v.load(ordering: .sequentiallyConsistent), DoubleWord(first: 100, second: 64))
 
-    let w: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 50, low: 32))
+    let w: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 50, second: 32))
     defer { w.destroy() }
-    XCTAssertEqual(w.load(ordering: .sequentiallyConsistent), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(w.load(ordering: .sequentiallyConsistent), DoubleWord(first: 50, second: 32))
   }
 
 
   func test_store_relaxed() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
-    v.store(DoubleWord(high: 50, low: 32), ordering: .relaxed)
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    v.store(DoubleWord(first: 50, second: 32), ordering: .relaxed)
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    let w: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 50, low: 32))
+    let w: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 50, second: 32))
     defer { w.destroy() }
-    w.store(DoubleWord(high: 100, low: 64), ordering: .relaxed)
-    XCTAssertEqual(w.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    w.store(DoubleWord(first: 100, second: 64), ordering: .relaxed)
+    XCTAssertEqual(w.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_store_releasing() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
-    v.store(DoubleWord(high: 50, low: 32), ordering: .releasing)
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    v.store(DoubleWord(first: 50, second: 32), ordering: .releasing)
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    let w: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 50, low: 32))
+    let w: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 50, second: 32))
     defer { w.destroy() }
-    w.store(DoubleWord(high: 100, low: 64), ordering: .releasing)
-    XCTAssertEqual(w.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    w.store(DoubleWord(first: 100, second: 64), ordering: .releasing)
+    XCTAssertEqual(w.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_store_sequentiallyConsistent() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
-    v.store(DoubleWord(high: 50, low: 32), ordering: .sequentiallyConsistent)
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    v.store(DoubleWord(first: 50, second: 32), ordering: .sequentiallyConsistent)
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    let w: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 50, low: 32))
+    let w: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 50, second: 32))
     defer { w.destroy() }
-    w.store(DoubleWord(high: 100, low: 64), ordering: .sequentiallyConsistent)
-    XCTAssertEqual(w.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    w.store(DoubleWord(first: 100, second: 64), ordering: .sequentiallyConsistent)
+    XCTAssertEqual(w.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
 
   func test_exchange_relaxed() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
-    XCTAssertEqual(v.exchange(DoubleWord(high: 100, low: 64), ordering: .relaxed), DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(v.exchange(DoubleWord(first: 100, second: 64), ordering: .relaxed), DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
-    XCTAssertEqual(v.exchange(DoubleWord(high: 50, low: 32), ordering: .relaxed), DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(v.exchange(DoubleWord(first: 50, second: 32), ordering: .relaxed), DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    XCTAssertEqual(v.exchange(DoubleWord(high: 50, low: 32), ordering: .relaxed), DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(v.exchange(DoubleWord(first: 50, second: 32), ordering: .relaxed), DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
   }
 
   func test_exchange_acquiring() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
-    XCTAssertEqual(v.exchange(DoubleWord(high: 100, low: 64), ordering: .acquiring), DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(v.exchange(DoubleWord(first: 100, second: 64), ordering: .acquiring), DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
-    XCTAssertEqual(v.exchange(DoubleWord(high: 50, low: 32), ordering: .acquiring), DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(v.exchange(DoubleWord(first: 50, second: 32), ordering: .acquiring), DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    XCTAssertEqual(v.exchange(DoubleWord(high: 50, low: 32), ordering: .acquiring), DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(v.exchange(DoubleWord(first: 50, second: 32), ordering: .acquiring), DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
   }
 
   func test_exchange_releasing() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
-    XCTAssertEqual(v.exchange(DoubleWord(high: 100, low: 64), ordering: .releasing), DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(v.exchange(DoubleWord(first: 100, second: 64), ordering: .releasing), DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
-    XCTAssertEqual(v.exchange(DoubleWord(high: 50, low: 32), ordering: .releasing), DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(v.exchange(DoubleWord(first: 50, second: 32), ordering: .releasing), DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    XCTAssertEqual(v.exchange(DoubleWord(high: 50, low: 32), ordering: .releasing), DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(v.exchange(DoubleWord(first: 50, second: 32), ordering: .releasing), DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
   }
 
   func test_exchange_acquiringAndReleasing() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
-    XCTAssertEqual(v.exchange(DoubleWord(high: 100, low: 64), ordering: .acquiringAndReleasing), DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(v.exchange(DoubleWord(first: 100, second: 64), ordering: .acquiringAndReleasing), DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
-    XCTAssertEqual(v.exchange(DoubleWord(high: 50, low: 32), ordering: .acquiringAndReleasing), DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(v.exchange(DoubleWord(first: 50, second: 32), ordering: .acquiringAndReleasing), DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    XCTAssertEqual(v.exchange(DoubleWord(high: 50, low: 32), ordering: .acquiringAndReleasing), DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(v.exchange(DoubleWord(first: 50, second: 32), ordering: .acquiringAndReleasing), DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
   }
 
   func test_exchange_sequentiallyConsistent() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
-    XCTAssertEqual(v.exchange(DoubleWord(high: 100, low: 64), ordering: .sequentiallyConsistent), DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(v.exchange(DoubleWord(first: 100, second: 64), ordering: .sequentiallyConsistent), DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
-    XCTAssertEqual(v.exchange(DoubleWord(high: 50, low: 32), ordering: .sequentiallyConsistent), DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(v.exchange(DoubleWord(first: 50, second: 32), ordering: .sequentiallyConsistent), DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    XCTAssertEqual(v.exchange(DoubleWord(high: 50, low: 32), ordering: .sequentiallyConsistent), DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(v.exchange(DoubleWord(first: 50, second: 32), ordering: .sequentiallyConsistent), DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
   }
 
 
   func test_compareExchange_relaxed() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       ordering: .relaxed)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       ordering: .relaxed)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       ordering: .relaxed)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       ordering: .relaxed)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_compareExchange_acquiring() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       ordering: .acquiring)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       ordering: .acquiring)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       ordering: .acquiring)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       ordering: .acquiring)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_compareExchange_releasing() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       ordering: .releasing)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       ordering: .releasing)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       ordering: .releasing)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       ordering: .releasing)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_compareExchange_acquiringAndReleasing() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       ordering: .acquiringAndReleasing)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       ordering: .acquiringAndReleasing)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       ordering: .acquiringAndReleasing)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       ordering: .acquiringAndReleasing)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_compareExchange_sequentiallyConsistent() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       ordering: .sequentiallyConsistent)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       ordering: .sequentiallyConsistent)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       ordering: .sequentiallyConsistent)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       ordering: .sequentiallyConsistent)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
 
   func test_compareExchange_relaxed_relaxed() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .relaxed,
       failureOrdering: .relaxed)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .relaxed,
       failureOrdering: .relaxed)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .relaxed,
       failureOrdering: .relaxed)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .relaxed,
       failureOrdering: .relaxed)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_compareExchange_relaxed_acquiring() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .relaxed,
       failureOrdering: .acquiring)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .relaxed,
       failureOrdering: .acquiring)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .relaxed,
       failureOrdering: .acquiring)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .relaxed,
       failureOrdering: .acquiring)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_compareExchange_relaxed_sequentiallyConsistent() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .relaxed,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .relaxed,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .relaxed,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .relaxed,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_compareExchange_acquiring_relaxed() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiring,
       failureOrdering: .relaxed)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiring,
       failureOrdering: .relaxed)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiring,
       failureOrdering: .relaxed)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiring,
       failureOrdering: .relaxed)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_compareExchange_acquiring_acquiring() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiring,
       failureOrdering: .acquiring)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiring,
       failureOrdering: .acquiring)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiring,
       failureOrdering: .acquiring)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiring,
       failureOrdering: .acquiring)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_compareExchange_acquiring_sequentiallyConsistent() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiring,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiring,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiring,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiring,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_compareExchange_releasing_relaxed() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .releasing,
       failureOrdering: .relaxed)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .releasing,
       failureOrdering: .relaxed)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .releasing,
       failureOrdering: .relaxed)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .releasing,
       failureOrdering: .relaxed)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_compareExchange_releasing_acquiring() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .releasing,
       failureOrdering: .acquiring)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .releasing,
       failureOrdering: .acquiring)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .releasing,
       failureOrdering: .acquiring)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .releasing,
       failureOrdering: .acquiring)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_compareExchange_releasing_sequentiallyConsistent() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .releasing,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .releasing,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .releasing,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .releasing,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_compareExchange_acquiringAndReleasing_relaxed() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiringAndReleasing,
       failureOrdering: .relaxed)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiringAndReleasing,
       failureOrdering: .relaxed)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiringAndReleasing,
       failureOrdering: .relaxed)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiringAndReleasing,
       failureOrdering: .relaxed)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_compareExchange_acquiringAndReleasing_acquiring() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiringAndReleasing,
       failureOrdering: .acquiring)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiringAndReleasing,
       failureOrdering: .acquiring)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiringAndReleasing,
       failureOrdering: .acquiring)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiringAndReleasing,
       failureOrdering: .acquiring)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_compareExchange_acquiringAndReleasing_sequentiallyConsistent() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiringAndReleasing,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiringAndReleasing,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiringAndReleasing,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiringAndReleasing,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_compareExchange_sequentiallyConsistent_relaxed() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .sequentiallyConsistent,
       failureOrdering: .relaxed)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .sequentiallyConsistent,
       failureOrdering: .relaxed)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .sequentiallyConsistent,
       failureOrdering: .relaxed)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .sequentiallyConsistent,
       failureOrdering: .relaxed)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_compareExchange_sequentiallyConsistent_acquiring() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .sequentiallyConsistent,
       failureOrdering: .acquiring)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .sequentiallyConsistent,
       failureOrdering: .acquiring)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .sequentiallyConsistent,
       failureOrdering: .acquiring)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .sequentiallyConsistent,
       failureOrdering: .acquiring)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_compareExchange_sequentiallyConsistent_sequentiallyConsistent() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .sequentiallyConsistent,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .sequentiallyConsistent,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .sequentiallyConsistent,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .sequentiallyConsistent,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_weakCompareExchange_relaxed_relaxed() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .relaxed,
       failureOrdering: .relaxed)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .relaxed,
       failureOrdering: .relaxed)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .relaxed,
       failureOrdering: .relaxed)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .relaxed,
       failureOrdering: .relaxed)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_weakCompareExchange_relaxed_acquiring() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .relaxed,
       failureOrdering: .acquiring)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .relaxed,
       failureOrdering: .acquiring)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .relaxed,
       failureOrdering: .acquiring)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .relaxed,
       failureOrdering: .acquiring)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_weakCompareExchange_relaxed_sequentiallyConsistent() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .relaxed,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .relaxed,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .relaxed,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .relaxed,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_weakCompareExchange_acquiring_relaxed() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiring,
       failureOrdering: .relaxed)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiring,
       failureOrdering: .relaxed)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiring,
       failureOrdering: .relaxed)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiring,
       failureOrdering: .relaxed)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_weakCompareExchange_acquiring_acquiring() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiring,
       failureOrdering: .acquiring)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiring,
       failureOrdering: .acquiring)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiring,
       failureOrdering: .acquiring)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiring,
       failureOrdering: .acquiring)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_weakCompareExchange_acquiring_sequentiallyConsistent() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiring,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiring,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiring,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiring,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_weakCompareExchange_releasing_relaxed() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .releasing,
       failureOrdering: .relaxed)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .releasing,
       failureOrdering: .relaxed)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .releasing,
       failureOrdering: .relaxed)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .releasing,
       failureOrdering: .relaxed)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_weakCompareExchange_releasing_acquiring() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .releasing,
       failureOrdering: .acquiring)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .releasing,
       failureOrdering: .acquiring)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .releasing,
       failureOrdering: .acquiring)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .releasing,
       failureOrdering: .acquiring)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_weakCompareExchange_releasing_sequentiallyConsistent() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .releasing,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .releasing,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .releasing,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .releasing,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_weakCompareExchange_acquiringAndReleasing_relaxed() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiringAndReleasing,
       failureOrdering: .relaxed)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiringAndReleasing,
       failureOrdering: .relaxed)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiringAndReleasing,
       failureOrdering: .relaxed)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiringAndReleasing,
       failureOrdering: .relaxed)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_weakCompareExchange_acquiringAndReleasing_acquiring() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiringAndReleasing,
       failureOrdering: .acquiring)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiringAndReleasing,
       failureOrdering: .acquiring)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiringAndReleasing,
       failureOrdering: .acquiring)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiringAndReleasing,
       failureOrdering: .acquiring)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_weakCompareExchange_acquiringAndReleasing_sequentiallyConsistent() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiringAndReleasing,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiringAndReleasing,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiringAndReleasing,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiringAndReleasing,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_weakCompareExchange_sequentiallyConsistent_relaxed() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .sequentiallyConsistent,
       failureOrdering: .relaxed)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .sequentiallyConsistent,
       failureOrdering: .relaxed)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .sequentiallyConsistent,
       failureOrdering: .relaxed)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .sequentiallyConsistent,
       failureOrdering: .relaxed)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_weakCompareExchange_sequentiallyConsistent_acquiring() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .sequentiallyConsistent,
       failureOrdering: .acquiring)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .sequentiallyConsistent,
       failureOrdering: .acquiring)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .sequentiallyConsistent,
       failureOrdering: .acquiring)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .sequentiallyConsistent,
       failureOrdering: .acquiring)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
   func test_weakCompareExchange_sequentiallyConsistent_sequentiallyConsistent() {
-    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(high: 100, low: 64))
+    let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
     var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .sequentiallyConsistent,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 100, low: 64),
-      desired: DoubleWord(high: 50, low: 32),
+      expected: DoubleWord(first: 100, second: 64),
+      desired: DoubleWord(first: 50, second: 32),
       successOrdering: .sequentiallyConsistent,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 50, low: 32))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .sequentiallyConsistent,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertTrue(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 50, low: 32))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
     (exchanged, original) = v.compareExchange(
-      expected: DoubleWord(high: 50, low: 32),
-      desired: DoubleWord(high: 100, low: 64),
+      expected: DoubleWord(first: 50, second: 32),
+      desired: DoubleWord(first: 100, second: 64),
       successOrdering: .sequentiallyConsistent,
       failureOrdering: .sequentiallyConsistent)
     XCTAssertFalse(exchanged)
-    XCTAssertEqual(original, DoubleWord(high: 100, low: 64))
-    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(high: 100, low: 64))
+    XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
+    XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
   }
 
 

--- a/Tests/AtomicsTests/DoubleWord.swift
+++ b/Tests/AtomicsTests/DoubleWord.swift
@@ -45,26 +45,25 @@ class DoubleWordTests: XCTestCase {
     XCTAssertEqual(componentsInMemoryOrder(of: value), UIntPair(1, 2))
   }
 
+  @available(*, deprecated)
   func testHighLowInitializer() {
     let value = DoubleWord(high: 1, low: 2)
-    #if _endian(little)
     XCTAssertEqual(componentsInMemoryOrder(of: value), UIntPair(2, 1))
-    #else
-    XCTAssertEqual(componentsInMemoryOrder(of: value), UIntPair(1, 2))
-    #endif
   }
 
   func testPropertyGetters() {
     let value = DoubleWord(first: UInt.max, second: 0)
     XCTAssertEqual(value.first, UInt.max)
     XCTAssertEqual(value.second, 0)
-    #if _endian(little)
+  }
+
+  @available(*, deprecated)
+  func testPropertyGetters_deprecated() {
+    let value = DoubleWord(first: UInt.max, second: 0)
+    XCTAssertEqual(value.first, UInt.max)
+    XCTAssertEqual(value.second, 0)
     XCTAssertEqual(value.high, 0)
     XCTAssertEqual(value.low, UInt.max)
-    #else
-    XCTAssertEqual(value.high, UInt.max)
-    XCTAssertEqual(value.low, 0)
-    #endif
   }
 
   func testPropertySetters() {
@@ -73,18 +72,15 @@ class DoubleWordTests: XCTestCase {
     XCTAssertEqual(componentsInMemoryOrder(of: value), UIntPair(3, 2))
     value.second = 4
     XCTAssertEqual(componentsInMemoryOrder(of: value), UIntPair(3, 4))
+  }
+
+  @available(*, deprecated)
+  func testPropertySetters_deprecated() {
+    var value = DoubleWord(first: 3, second: 4)
     value.low = 5
-    #if _endian(little)
     XCTAssertEqual(componentsInMemoryOrder(of: value), UIntPair(5, 4))
-    #else
-    XCTAssertEqual(componentsInMemoryOrder(of: value), UIntPair(3, 5))
-    #endif
     value.high = 6
-    #if _endian(little)
     XCTAssertEqual(componentsInMemoryOrder(of: value), UIntPair(5, 6))
-    #else
-    XCTAssertEqual(componentsInMemoryOrder(of: value), UIntPair(6, 5))
-    #endif
   }
 
 #if MANUAL_TEST_DISCOVERY


### PR DESCRIPTION
Now that we can rely on https://reviews.llvm.org/D86218, we don’t need to tiptoe around the use of `_Atomic(struct _sa_dword)`.

Rip out the clumsy encode/decode mess and the use of `__uint128_t`.

As a side effect of removing the use of `__uint128_t`, this PR deprecates the `DoubleWord.low` and `DoubleWord.high` properties (and the associated initializer), replacing them with `first` and `second`.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-atomics)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [X] I've verified that my change does not break any existing tests.
- [ ] I've updated the documentation if necessary.
