### PR TITLE
[test] Fix basic tests to to actually cover weakCompareExchange

### DIFF
--- a/Tests/AtomicsTests/Basics/BasicTests.gyb-template
+++ b/Tests/AtomicsTests/Basics/BasicTests.gyb-template
@@ -172,7 +172,7 @@ class BasicAtomic${label}Tests: XCTestCase {
     let v: UnsafeAtomic<${type}> = .create(${a})
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, ${type}) = v.compareExchange(
+    var (exchanged, original): (Bool, ${type}) = v.${operation}(
       expected: ${a},
       desired: ${b},
       successOrdering: .${successorder},
@@ -181,7 +181,7 @@ class BasicAtomic${label}Tests: XCTestCase {
     XCTAssertEqual(original, ${a})
     XCTAssertEqual(v.load(ordering: .relaxed), ${b})
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.${operation}(
       expected: ${a},
       desired: ${b},
       successOrdering: .${successorder},
@@ -190,7 +190,7 @@ class BasicAtomic${label}Tests: XCTestCase {
     XCTAssertEqual(original, ${b})
     XCTAssertEqual(v.load(ordering: .relaxed), ${b})
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.${operation}(
       expected: ${b},
       desired: ${a},
       successOrdering: .${successorder},
@@ -199,7 +199,7 @@ class BasicAtomic${label}Tests: XCTestCase {
     XCTAssertEqual(original, ${b})
     XCTAssertEqual(v.load(ordering: .relaxed), ${a})
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.${operation}(
       expected: ${b},
       desired: ${a},
       successOrdering: .${successorder},

--- a/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicBoolTests.swift
+++ b/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicBoolTests.swift
@@ -979,7 +979,7 @@ class BasicAtomicBoolTests: XCTestCase {
     let v: UnsafeAtomic<Bool> = .create(true)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Bool) = v.compareExchange(
+    var (exchanged, original): (Bool, Bool) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .relaxed,
@@ -988,7 +988,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, true)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .relaxed,
@@ -997,7 +997,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .relaxed,
@@ -1006,7 +1006,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), true)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .relaxed,
@@ -1020,7 +1020,7 @@ class BasicAtomicBoolTests: XCTestCase {
     let v: UnsafeAtomic<Bool> = .create(true)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Bool) = v.compareExchange(
+    var (exchanged, original): (Bool, Bool) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .relaxed,
@@ -1029,7 +1029,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, true)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .relaxed,
@@ -1038,7 +1038,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .relaxed,
@@ -1047,7 +1047,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), true)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .relaxed,
@@ -1061,7 +1061,7 @@ class BasicAtomicBoolTests: XCTestCase {
     let v: UnsafeAtomic<Bool> = .create(true)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Bool) = v.compareExchange(
+    var (exchanged, original): (Bool, Bool) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .relaxed,
@@ -1070,7 +1070,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, true)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .relaxed,
@@ -1079,7 +1079,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .relaxed,
@@ -1088,7 +1088,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), true)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .relaxed,
@@ -1102,7 +1102,7 @@ class BasicAtomicBoolTests: XCTestCase {
     let v: UnsafeAtomic<Bool> = .create(true)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Bool) = v.compareExchange(
+    var (exchanged, original): (Bool, Bool) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .acquiring,
@@ -1111,7 +1111,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, true)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .acquiring,
@@ -1120,7 +1120,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .acquiring,
@@ -1129,7 +1129,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), true)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .acquiring,
@@ -1143,7 +1143,7 @@ class BasicAtomicBoolTests: XCTestCase {
     let v: UnsafeAtomic<Bool> = .create(true)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Bool) = v.compareExchange(
+    var (exchanged, original): (Bool, Bool) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .acquiring,
@@ -1152,7 +1152,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, true)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .acquiring,
@@ -1161,7 +1161,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .acquiring,
@@ -1170,7 +1170,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), true)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .acquiring,
@@ -1184,7 +1184,7 @@ class BasicAtomicBoolTests: XCTestCase {
     let v: UnsafeAtomic<Bool> = .create(true)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Bool) = v.compareExchange(
+    var (exchanged, original): (Bool, Bool) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .acquiring,
@@ -1193,7 +1193,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, true)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .acquiring,
@@ -1202,7 +1202,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .acquiring,
@@ -1211,7 +1211,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), true)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .acquiring,
@@ -1225,7 +1225,7 @@ class BasicAtomicBoolTests: XCTestCase {
     let v: UnsafeAtomic<Bool> = .create(true)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Bool) = v.compareExchange(
+    var (exchanged, original): (Bool, Bool) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .releasing,
@@ -1234,7 +1234,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, true)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .releasing,
@@ -1243,7 +1243,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .releasing,
@@ -1252,7 +1252,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), true)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .releasing,
@@ -1266,7 +1266,7 @@ class BasicAtomicBoolTests: XCTestCase {
     let v: UnsafeAtomic<Bool> = .create(true)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Bool) = v.compareExchange(
+    var (exchanged, original): (Bool, Bool) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .releasing,
@@ -1275,7 +1275,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, true)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .releasing,
@@ -1284,7 +1284,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .releasing,
@@ -1293,7 +1293,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), true)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .releasing,
@@ -1307,7 +1307,7 @@ class BasicAtomicBoolTests: XCTestCase {
     let v: UnsafeAtomic<Bool> = .create(true)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Bool) = v.compareExchange(
+    var (exchanged, original): (Bool, Bool) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .releasing,
@@ -1316,7 +1316,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, true)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .releasing,
@@ -1325,7 +1325,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .releasing,
@@ -1334,7 +1334,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), true)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .releasing,
@@ -1348,7 +1348,7 @@ class BasicAtomicBoolTests: XCTestCase {
     let v: UnsafeAtomic<Bool> = .create(true)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Bool) = v.compareExchange(
+    var (exchanged, original): (Bool, Bool) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .acquiringAndReleasing,
@@ -1357,7 +1357,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, true)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .acquiringAndReleasing,
@@ -1366,7 +1366,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .acquiringAndReleasing,
@@ -1375,7 +1375,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), true)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .acquiringAndReleasing,
@@ -1389,7 +1389,7 @@ class BasicAtomicBoolTests: XCTestCase {
     let v: UnsafeAtomic<Bool> = .create(true)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Bool) = v.compareExchange(
+    var (exchanged, original): (Bool, Bool) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .acquiringAndReleasing,
@@ -1398,7 +1398,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, true)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .acquiringAndReleasing,
@@ -1407,7 +1407,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .acquiringAndReleasing,
@@ -1416,7 +1416,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), true)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .acquiringAndReleasing,
@@ -1430,7 +1430,7 @@ class BasicAtomicBoolTests: XCTestCase {
     let v: UnsafeAtomic<Bool> = .create(true)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Bool) = v.compareExchange(
+    var (exchanged, original): (Bool, Bool) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .acquiringAndReleasing,
@@ -1439,7 +1439,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, true)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .acquiringAndReleasing,
@@ -1448,7 +1448,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .acquiringAndReleasing,
@@ -1457,7 +1457,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), true)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .acquiringAndReleasing,
@@ -1471,7 +1471,7 @@ class BasicAtomicBoolTests: XCTestCase {
     let v: UnsafeAtomic<Bool> = .create(true)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Bool) = v.compareExchange(
+    var (exchanged, original): (Bool, Bool) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .sequentiallyConsistent,
@@ -1480,7 +1480,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, true)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .sequentiallyConsistent,
@@ -1489,7 +1489,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .sequentiallyConsistent,
@@ -1498,7 +1498,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), true)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .sequentiallyConsistent,
@@ -1512,7 +1512,7 @@ class BasicAtomicBoolTests: XCTestCase {
     let v: UnsafeAtomic<Bool> = .create(true)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Bool) = v.compareExchange(
+    var (exchanged, original): (Bool, Bool) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .sequentiallyConsistent,
@@ -1521,7 +1521,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, true)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .sequentiallyConsistent,
@@ -1530,7 +1530,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .sequentiallyConsistent,
@@ -1539,7 +1539,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), true)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .sequentiallyConsistent,
@@ -1553,7 +1553,7 @@ class BasicAtomicBoolTests: XCTestCase {
     let v: UnsafeAtomic<Bool> = .create(true)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Bool) = v.compareExchange(
+    var (exchanged, original): (Bool, Bool) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .sequentiallyConsistent,
@@ -1562,7 +1562,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, true)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: true,
       desired: false,
       successOrdering: .sequentiallyConsistent,
@@ -1571,7 +1571,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), false)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .sequentiallyConsistent,
@@ -1580,7 +1580,7 @@ class BasicAtomicBoolTests: XCTestCase {
     XCTAssertEqual(original, false)
     XCTAssertEqual(v.load(ordering: .relaxed), true)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: false,
       desired: true,
       successOrdering: .sequentiallyConsistent,

--- a/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicDoubleWordTests.swift
+++ b/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicDoubleWordTests.swift
@@ -979,7 +979,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
+    var (exchanged, original): (Bool, DoubleWord) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .relaxed,
@@ -988,7 +988,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .relaxed,
@@ -997,7 +997,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .relaxed,
@@ -1006,7 +1006,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .relaxed,
@@ -1020,7 +1020,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
+    var (exchanged, original): (Bool, DoubleWord) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .relaxed,
@@ -1029,7 +1029,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .relaxed,
@@ -1038,7 +1038,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .relaxed,
@@ -1047,7 +1047,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .relaxed,
@@ -1061,7 +1061,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
+    var (exchanged, original): (Bool, DoubleWord) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .relaxed,
@@ -1070,7 +1070,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .relaxed,
@@ -1079,7 +1079,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .relaxed,
@@ -1088,7 +1088,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .relaxed,
@@ -1102,7 +1102,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
+    var (exchanged, original): (Bool, DoubleWord) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiring,
@@ -1111,7 +1111,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiring,
@@ -1120,7 +1120,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiring,
@@ -1129,7 +1129,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiring,
@@ -1143,7 +1143,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
+    var (exchanged, original): (Bool, DoubleWord) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiring,
@@ -1152,7 +1152,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiring,
@@ -1161,7 +1161,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiring,
@@ -1170,7 +1170,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiring,
@@ -1184,7 +1184,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
+    var (exchanged, original): (Bool, DoubleWord) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiring,
@@ -1193,7 +1193,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiring,
@@ -1202,7 +1202,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiring,
@@ -1211,7 +1211,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiring,
@@ -1225,7 +1225,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
+    var (exchanged, original): (Bool, DoubleWord) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .releasing,
@@ -1234,7 +1234,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .releasing,
@@ -1243,7 +1243,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .releasing,
@@ -1252,7 +1252,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .releasing,
@@ -1266,7 +1266,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
+    var (exchanged, original): (Bool, DoubleWord) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .releasing,
@@ -1275,7 +1275,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .releasing,
@@ -1284,7 +1284,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .releasing,
@@ -1293,7 +1293,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .releasing,
@@ -1307,7 +1307,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
+    var (exchanged, original): (Bool, DoubleWord) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .releasing,
@@ -1316,7 +1316,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .releasing,
@@ -1325,7 +1325,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .releasing,
@@ -1334,7 +1334,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .releasing,
@@ -1348,7 +1348,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
+    var (exchanged, original): (Bool, DoubleWord) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiringAndReleasing,
@@ -1357,7 +1357,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiringAndReleasing,
@@ -1366,7 +1366,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiringAndReleasing,
@@ -1375,7 +1375,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiringAndReleasing,
@@ -1389,7 +1389,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
+    var (exchanged, original): (Bool, DoubleWord) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiringAndReleasing,
@@ -1398,7 +1398,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiringAndReleasing,
@@ -1407,7 +1407,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiringAndReleasing,
@@ -1416,7 +1416,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiringAndReleasing,
@@ -1430,7 +1430,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
+    var (exchanged, original): (Bool, DoubleWord) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiringAndReleasing,
@@ -1439,7 +1439,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .acquiringAndReleasing,
@@ -1448,7 +1448,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiringAndReleasing,
@@ -1457,7 +1457,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .acquiringAndReleasing,
@@ -1471,7 +1471,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
+    var (exchanged, original): (Bool, DoubleWord) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .sequentiallyConsistent,
@@ -1480,7 +1480,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .sequentiallyConsistent,
@@ -1489,7 +1489,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .sequentiallyConsistent,
@@ -1498,7 +1498,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .sequentiallyConsistent,
@@ -1512,7 +1512,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
+    var (exchanged, original): (Bool, DoubleWord) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .sequentiallyConsistent,
@@ -1521,7 +1521,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .sequentiallyConsistent,
@@ -1530,7 +1530,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .sequentiallyConsistent,
@@ -1539,7 +1539,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .sequentiallyConsistent,
@@ -1553,7 +1553,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     let v: UnsafeAtomic<DoubleWord> = .create(DoubleWord(first: 100, second: 64))
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, DoubleWord) = v.compareExchange(
+    var (exchanged, original): (Bool, DoubleWord) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .sequentiallyConsistent,
@@ -1562,7 +1562,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 100, second: 64))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 100, second: 64),
       desired: DoubleWord(first: 50, second: 32),
       successOrdering: .sequentiallyConsistent,
@@ -1571,7 +1571,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 50, second: 32))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .sequentiallyConsistent,
@@ -1580,7 +1580,7 @@ class BasicAtomicDoubleWordTests: XCTestCase {
     XCTAssertEqual(original, DoubleWord(first: 50, second: 32))
     XCTAssertEqual(v.load(ordering: .relaxed), DoubleWord(first: 100, second: 64))
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: DoubleWord(first: 50, second: 32),
       desired: DoubleWord(first: 100, second: 64),
       successOrdering: .sequentiallyConsistent,

--- a/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicInt16Tests.swift
+++ b/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicInt16Tests.swift
@@ -979,7 +979,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     let v: UnsafeAtomic<Int16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int16) = v.compareExchange(
+    var (exchanged, original): (Bool, Int16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -988,7 +988,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -997,7 +997,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1006,7 +1006,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1020,7 +1020,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     let v: UnsafeAtomic<Int16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int16) = v.compareExchange(
+    var (exchanged, original): (Bool, Int16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1029,7 +1029,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1038,7 +1038,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1047,7 +1047,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1061,7 +1061,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     let v: UnsafeAtomic<Int16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int16) = v.compareExchange(
+    var (exchanged, original): (Bool, Int16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1070,7 +1070,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1079,7 +1079,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1088,7 +1088,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1102,7 +1102,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     let v: UnsafeAtomic<Int16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int16) = v.compareExchange(
+    var (exchanged, original): (Bool, Int16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1111,7 +1111,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1120,7 +1120,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1129,7 +1129,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1143,7 +1143,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     let v: UnsafeAtomic<Int16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int16) = v.compareExchange(
+    var (exchanged, original): (Bool, Int16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1152,7 +1152,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1161,7 +1161,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1170,7 +1170,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1184,7 +1184,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     let v: UnsafeAtomic<Int16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int16) = v.compareExchange(
+    var (exchanged, original): (Bool, Int16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1193,7 +1193,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1202,7 +1202,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1211,7 +1211,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1225,7 +1225,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     let v: UnsafeAtomic<Int16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int16) = v.compareExchange(
+    var (exchanged, original): (Bool, Int16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1234,7 +1234,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1243,7 +1243,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1252,7 +1252,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1266,7 +1266,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     let v: UnsafeAtomic<Int16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int16) = v.compareExchange(
+    var (exchanged, original): (Bool, Int16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1275,7 +1275,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1284,7 +1284,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1293,7 +1293,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1307,7 +1307,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     let v: UnsafeAtomic<Int16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int16) = v.compareExchange(
+    var (exchanged, original): (Bool, Int16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1316,7 +1316,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1325,7 +1325,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1334,7 +1334,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1348,7 +1348,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     let v: UnsafeAtomic<Int16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int16) = v.compareExchange(
+    var (exchanged, original): (Bool, Int16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1357,7 +1357,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1366,7 +1366,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1375,7 +1375,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1389,7 +1389,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     let v: UnsafeAtomic<Int16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int16) = v.compareExchange(
+    var (exchanged, original): (Bool, Int16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1398,7 +1398,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1407,7 +1407,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1416,7 +1416,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1430,7 +1430,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     let v: UnsafeAtomic<Int16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int16) = v.compareExchange(
+    var (exchanged, original): (Bool, Int16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1439,7 +1439,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1448,7 +1448,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1457,7 +1457,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1471,7 +1471,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     let v: UnsafeAtomic<Int16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int16) = v.compareExchange(
+    var (exchanged, original): (Bool, Int16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1480,7 +1480,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1489,7 +1489,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1498,7 +1498,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1512,7 +1512,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     let v: UnsafeAtomic<Int16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int16) = v.compareExchange(
+    var (exchanged, original): (Bool, Int16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1521,7 +1521,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1530,7 +1530,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1539,7 +1539,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1553,7 +1553,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     let v: UnsafeAtomic<Int16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int16) = v.compareExchange(
+    var (exchanged, original): (Bool, Int16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1562,7 +1562,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1571,7 +1571,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1580,7 +1580,7 @@ class BasicAtomicInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,

--- a/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicInt32Tests.swift
+++ b/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicInt32Tests.swift
@@ -979,7 +979,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     let v: UnsafeAtomic<Int32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int32) = v.compareExchange(
+    var (exchanged, original): (Bool, Int32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -988,7 +988,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -997,7 +997,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1006,7 +1006,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1020,7 +1020,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     let v: UnsafeAtomic<Int32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int32) = v.compareExchange(
+    var (exchanged, original): (Bool, Int32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1029,7 +1029,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1038,7 +1038,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1047,7 +1047,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1061,7 +1061,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     let v: UnsafeAtomic<Int32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int32) = v.compareExchange(
+    var (exchanged, original): (Bool, Int32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1070,7 +1070,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1079,7 +1079,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1088,7 +1088,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1102,7 +1102,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     let v: UnsafeAtomic<Int32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int32) = v.compareExchange(
+    var (exchanged, original): (Bool, Int32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1111,7 +1111,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1120,7 +1120,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1129,7 +1129,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1143,7 +1143,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     let v: UnsafeAtomic<Int32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int32) = v.compareExchange(
+    var (exchanged, original): (Bool, Int32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1152,7 +1152,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1161,7 +1161,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1170,7 +1170,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1184,7 +1184,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     let v: UnsafeAtomic<Int32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int32) = v.compareExchange(
+    var (exchanged, original): (Bool, Int32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1193,7 +1193,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1202,7 +1202,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1211,7 +1211,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1225,7 +1225,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     let v: UnsafeAtomic<Int32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int32) = v.compareExchange(
+    var (exchanged, original): (Bool, Int32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1234,7 +1234,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1243,7 +1243,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1252,7 +1252,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1266,7 +1266,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     let v: UnsafeAtomic<Int32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int32) = v.compareExchange(
+    var (exchanged, original): (Bool, Int32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1275,7 +1275,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1284,7 +1284,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1293,7 +1293,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1307,7 +1307,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     let v: UnsafeAtomic<Int32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int32) = v.compareExchange(
+    var (exchanged, original): (Bool, Int32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1316,7 +1316,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1325,7 +1325,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1334,7 +1334,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1348,7 +1348,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     let v: UnsafeAtomic<Int32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int32) = v.compareExchange(
+    var (exchanged, original): (Bool, Int32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1357,7 +1357,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1366,7 +1366,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1375,7 +1375,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1389,7 +1389,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     let v: UnsafeAtomic<Int32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int32) = v.compareExchange(
+    var (exchanged, original): (Bool, Int32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1398,7 +1398,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1407,7 +1407,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1416,7 +1416,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1430,7 +1430,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     let v: UnsafeAtomic<Int32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int32) = v.compareExchange(
+    var (exchanged, original): (Bool, Int32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1439,7 +1439,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1448,7 +1448,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1457,7 +1457,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1471,7 +1471,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     let v: UnsafeAtomic<Int32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int32) = v.compareExchange(
+    var (exchanged, original): (Bool, Int32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1480,7 +1480,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1489,7 +1489,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1498,7 +1498,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1512,7 +1512,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     let v: UnsafeAtomic<Int32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int32) = v.compareExchange(
+    var (exchanged, original): (Bool, Int32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1521,7 +1521,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1530,7 +1530,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1539,7 +1539,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1553,7 +1553,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     let v: UnsafeAtomic<Int32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int32) = v.compareExchange(
+    var (exchanged, original): (Bool, Int32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1562,7 +1562,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1571,7 +1571,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1580,7 +1580,7 @@ class BasicAtomicInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,

--- a/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicInt64Tests.swift
+++ b/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicInt64Tests.swift
@@ -979,7 +979,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     let v: UnsafeAtomic<Int64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int64) = v.compareExchange(
+    var (exchanged, original): (Bool, Int64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -988,7 +988,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -997,7 +997,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1006,7 +1006,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1020,7 +1020,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     let v: UnsafeAtomic<Int64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int64) = v.compareExchange(
+    var (exchanged, original): (Bool, Int64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1029,7 +1029,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1038,7 +1038,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1047,7 +1047,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1061,7 +1061,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     let v: UnsafeAtomic<Int64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int64) = v.compareExchange(
+    var (exchanged, original): (Bool, Int64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1070,7 +1070,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1079,7 +1079,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1088,7 +1088,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1102,7 +1102,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     let v: UnsafeAtomic<Int64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int64) = v.compareExchange(
+    var (exchanged, original): (Bool, Int64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1111,7 +1111,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1120,7 +1120,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1129,7 +1129,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1143,7 +1143,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     let v: UnsafeAtomic<Int64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int64) = v.compareExchange(
+    var (exchanged, original): (Bool, Int64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1152,7 +1152,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1161,7 +1161,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1170,7 +1170,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1184,7 +1184,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     let v: UnsafeAtomic<Int64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int64) = v.compareExchange(
+    var (exchanged, original): (Bool, Int64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1193,7 +1193,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1202,7 +1202,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1211,7 +1211,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1225,7 +1225,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     let v: UnsafeAtomic<Int64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int64) = v.compareExchange(
+    var (exchanged, original): (Bool, Int64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1234,7 +1234,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1243,7 +1243,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1252,7 +1252,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1266,7 +1266,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     let v: UnsafeAtomic<Int64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int64) = v.compareExchange(
+    var (exchanged, original): (Bool, Int64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1275,7 +1275,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1284,7 +1284,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1293,7 +1293,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1307,7 +1307,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     let v: UnsafeAtomic<Int64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int64) = v.compareExchange(
+    var (exchanged, original): (Bool, Int64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1316,7 +1316,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1325,7 +1325,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1334,7 +1334,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1348,7 +1348,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     let v: UnsafeAtomic<Int64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int64) = v.compareExchange(
+    var (exchanged, original): (Bool, Int64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1357,7 +1357,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1366,7 +1366,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1375,7 +1375,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1389,7 +1389,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     let v: UnsafeAtomic<Int64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int64) = v.compareExchange(
+    var (exchanged, original): (Bool, Int64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1398,7 +1398,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1407,7 +1407,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1416,7 +1416,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1430,7 +1430,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     let v: UnsafeAtomic<Int64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int64) = v.compareExchange(
+    var (exchanged, original): (Bool, Int64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1439,7 +1439,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1448,7 +1448,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1457,7 +1457,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1471,7 +1471,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     let v: UnsafeAtomic<Int64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int64) = v.compareExchange(
+    var (exchanged, original): (Bool, Int64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1480,7 +1480,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1489,7 +1489,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1498,7 +1498,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1512,7 +1512,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     let v: UnsafeAtomic<Int64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int64) = v.compareExchange(
+    var (exchanged, original): (Bool, Int64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1521,7 +1521,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1530,7 +1530,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1539,7 +1539,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1553,7 +1553,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     let v: UnsafeAtomic<Int64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int64) = v.compareExchange(
+    var (exchanged, original): (Bool, Int64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1562,7 +1562,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1571,7 +1571,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1580,7 +1580,7 @@ class BasicAtomicInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,

--- a/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicInt8Tests.swift
+++ b/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicInt8Tests.swift
@@ -979,7 +979,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     let v: UnsafeAtomic<Int8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int8) = v.compareExchange(
+    var (exchanged, original): (Bool, Int8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -988,7 +988,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -997,7 +997,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1006,7 +1006,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1020,7 +1020,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     let v: UnsafeAtomic<Int8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int8) = v.compareExchange(
+    var (exchanged, original): (Bool, Int8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1029,7 +1029,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1038,7 +1038,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1047,7 +1047,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1061,7 +1061,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     let v: UnsafeAtomic<Int8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int8) = v.compareExchange(
+    var (exchanged, original): (Bool, Int8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1070,7 +1070,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1079,7 +1079,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1088,7 +1088,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1102,7 +1102,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     let v: UnsafeAtomic<Int8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int8) = v.compareExchange(
+    var (exchanged, original): (Bool, Int8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1111,7 +1111,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1120,7 +1120,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1129,7 +1129,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1143,7 +1143,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     let v: UnsafeAtomic<Int8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int8) = v.compareExchange(
+    var (exchanged, original): (Bool, Int8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1152,7 +1152,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1161,7 +1161,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1170,7 +1170,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1184,7 +1184,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     let v: UnsafeAtomic<Int8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int8) = v.compareExchange(
+    var (exchanged, original): (Bool, Int8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1193,7 +1193,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1202,7 +1202,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1211,7 +1211,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1225,7 +1225,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     let v: UnsafeAtomic<Int8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int8) = v.compareExchange(
+    var (exchanged, original): (Bool, Int8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1234,7 +1234,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1243,7 +1243,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1252,7 +1252,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1266,7 +1266,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     let v: UnsafeAtomic<Int8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int8) = v.compareExchange(
+    var (exchanged, original): (Bool, Int8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1275,7 +1275,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1284,7 +1284,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1293,7 +1293,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1307,7 +1307,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     let v: UnsafeAtomic<Int8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int8) = v.compareExchange(
+    var (exchanged, original): (Bool, Int8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1316,7 +1316,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1325,7 +1325,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1334,7 +1334,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1348,7 +1348,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     let v: UnsafeAtomic<Int8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int8) = v.compareExchange(
+    var (exchanged, original): (Bool, Int8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1357,7 +1357,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1366,7 +1366,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1375,7 +1375,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1389,7 +1389,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     let v: UnsafeAtomic<Int8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int8) = v.compareExchange(
+    var (exchanged, original): (Bool, Int8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1398,7 +1398,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1407,7 +1407,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1416,7 +1416,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1430,7 +1430,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     let v: UnsafeAtomic<Int8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int8) = v.compareExchange(
+    var (exchanged, original): (Bool, Int8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1439,7 +1439,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1448,7 +1448,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1457,7 +1457,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1471,7 +1471,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     let v: UnsafeAtomic<Int8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int8) = v.compareExchange(
+    var (exchanged, original): (Bool, Int8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1480,7 +1480,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1489,7 +1489,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1498,7 +1498,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1512,7 +1512,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     let v: UnsafeAtomic<Int8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int8) = v.compareExchange(
+    var (exchanged, original): (Bool, Int8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1521,7 +1521,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1530,7 +1530,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1539,7 +1539,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1553,7 +1553,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     let v: UnsafeAtomic<Int8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int8) = v.compareExchange(
+    var (exchanged, original): (Bool, Int8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1562,7 +1562,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1571,7 +1571,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1580,7 +1580,7 @@ class BasicAtomicInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,

--- a/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicIntTests.swift
+++ b/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicIntTests.swift
@@ -979,7 +979,7 @@ class BasicAtomicIntTests: XCTestCase {
     let v: UnsafeAtomic<Int> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int) = v.compareExchange(
+    var (exchanged, original): (Bool, Int) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -988,7 +988,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -997,7 +997,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1006,7 +1006,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1020,7 +1020,7 @@ class BasicAtomicIntTests: XCTestCase {
     let v: UnsafeAtomic<Int> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int) = v.compareExchange(
+    var (exchanged, original): (Bool, Int) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1029,7 +1029,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1038,7 +1038,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1047,7 +1047,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1061,7 +1061,7 @@ class BasicAtomicIntTests: XCTestCase {
     let v: UnsafeAtomic<Int> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int) = v.compareExchange(
+    var (exchanged, original): (Bool, Int) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1070,7 +1070,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1079,7 +1079,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1088,7 +1088,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1102,7 +1102,7 @@ class BasicAtomicIntTests: XCTestCase {
     let v: UnsafeAtomic<Int> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int) = v.compareExchange(
+    var (exchanged, original): (Bool, Int) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1111,7 +1111,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1120,7 +1120,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1129,7 +1129,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1143,7 +1143,7 @@ class BasicAtomicIntTests: XCTestCase {
     let v: UnsafeAtomic<Int> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int) = v.compareExchange(
+    var (exchanged, original): (Bool, Int) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1152,7 +1152,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1161,7 +1161,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1170,7 +1170,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1184,7 +1184,7 @@ class BasicAtomicIntTests: XCTestCase {
     let v: UnsafeAtomic<Int> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int) = v.compareExchange(
+    var (exchanged, original): (Bool, Int) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1193,7 +1193,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1202,7 +1202,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1211,7 +1211,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1225,7 +1225,7 @@ class BasicAtomicIntTests: XCTestCase {
     let v: UnsafeAtomic<Int> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int) = v.compareExchange(
+    var (exchanged, original): (Bool, Int) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1234,7 +1234,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1243,7 +1243,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1252,7 +1252,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1266,7 +1266,7 @@ class BasicAtomicIntTests: XCTestCase {
     let v: UnsafeAtomic<Int> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int) = v.compareExchange(
+    var (exchanged, original): (Bool, Int) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1275,7 +1275,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1284,7 +1284,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1293,7 +1293,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1307,7 +1307,7 @@ class BasicAtomicIntTests: XCTestCase {
     let v: UnsafeAtomic<Int> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int) = v.compareExchange(
+    var (exchanged, original): (Bool, Int) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1316,7 +1316,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1325,7 +1325,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1334,7 +1334,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1348,7 +1348,7 @@ class BasicAtomicIntTests: XCTestCase {
     let v: UnsafeAtomic<Int> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int) = v.compareExchange(
+    var (exchanged, original): (Bool, Int) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1357,7 +1357,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1366,7 +1366,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1375,7 +1375,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1389,7 +1389,7 @@ class BasicAtomicIntTests: XCTestCase {
     let v: UnsafeAtomic<Int> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int) = v.compareExchange(
+    var (exchanged, original): (Bool, Int) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1398,7 +1398,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1407,7 +1407,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1416,7 +1416,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1430,7 +1430,7 @@ class BasicAtomicIntTests: XCTestCase {
     let v: UnsafeAtomic<Int> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int) = v.compareExchange(
+    var (exchanged, original): (Bool, Int) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1439,7 +1439,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1448,7 +1448,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1457,7 +1457,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1471,7 +1471,7 @@ class BasicAtomicIntTests: XCTestCase {
     let v: UnsafeAtomic<Int> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int) = v.compareExchange(
+    var (exchanged, original): (Bool, Int) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1480,7 +1480,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1489,7 +1489,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1498,7 +1498,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1512,7 +1512,7 @@ class BasicAtomicIntTests: XCTestCase {
     let v: UnsafeAtomic<Int> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int) = v.compareExchange(
+    var (exchanged, original): (Bool, Int) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1521,7 +1521,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1530,7 +1530,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1539,7 +1539,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1553,7 +1553,7 @@ class BasicAtomicIntTests: XCTestCase {
     let v: UnsafeAtomic<Int> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Int) = v.compareExchange(
+    var (exchanged, original): (Bool, Int) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1562,7 +1562,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1571,7 +1571,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1580,7 +1580,7 @@ class BasicAtomicIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,

--- a/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicMutablePointerTests.swift
+++ b/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicMutablePointerTests.swift
@@ -1000,7 +1000,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>> = .create(_mfoo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .relaxed,
@@ -1009,7 +1009,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .relaxed,
@@ -1018,7 +1018,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .relaxed,
@@ -1027,7 +1027,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .relaxed,
@@ -1041,7 +1041,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>> = .create(_mfoo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .relaxed,
@@ -1050,7 +1050,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .relaxed,
@@ -1059,7 +1059,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .relaxed,
@@ -1068,7 +1068,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .relaxed,
@@ -1082,7 +1082,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>> = .create(_mfoo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .relaxed,
@@ -1091,7 +1091,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .relaxed,
@@ -1100,7 +1100,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .relaxed,
@@ -1109,7 +1109,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .relaxed,
@@ -1123,7 +1123,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>> = .create(_mfoo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .acquiring,
@@ -1132,7 +1132,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .acquiring,
@@ -1141,7 +1141,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .acquiring,
@@ -1150,7 +1150,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .acquiring,
@@ -1164,7 +1164,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>> = .create(_mfoo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .acquiring,
@@ -1173,7 +1173,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .acquiring,
@@ -1182,7 +1182,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .acquiring,
@@ -1191,7 +1191,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .acquiring,
@@ -1205,7 +1205,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>> = .create(_mfoo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .acquiring,
@@ -1214,7 +1214,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .acquiring,
@@ -1223,7 +1223,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .acquiring,
@@ -1232,7 +1232,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .acquiring,
@@ -1246,7 +1246,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>> = .create(_mfoo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .releasing,
@@ -1255,7 +1255,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .releasing,
@@ -1264,7 +1264,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .releasing,
@@ -1273,7 +1273,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .releasing,
@@ -1287,7 +1287,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>> = .create(_mfoo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .releasing,
@@ -1296,7 +1296,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .releasing,
@@ -1305,7 +1305,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .releasing,
@@ -1314,7 +1314,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .releasing,
@@ -1328,7 +1328,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>> = .create(_mfoo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .releasing,
@@ -1337,7 +1337,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .releasing,
@@ -1346,7 +1346,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .releasing,
@@ -1355,7 +1355,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .releasing,
@@ -1369,7 +1369,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>> = .create(_mfoo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .acquiringAndReleasing,
@@ -1378,7 +1378,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .acquiringAndReleasing,
@@ -1387,7 +1387,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .acquiringAndReleasing,
@@ -1396,7 +1396,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .acquiringAndReleasing,
@@ -1410,7 +1410,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>> = .create(_mfoo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .acquiringAndReleasing,
@@ -1419,7 +1419,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .acquiringAndReleasing,
@@ -1428,7 +1428,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .acquiringAndReleasing,
@@ -1437,7 +1437,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .acquiringAndReleasing,
@@ -1451,7 +1451,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>> = .create(_mfoo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .acquiringAndReleasing,
@@ -1460,7 +1460,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .acquiringAndReleasing,
@@ -1469,7 +1469,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .acquiringAndReleasing,
@@ -1478,7 +1478,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .acquiringAndReleasing,
@@ -1492,7 +1492,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>> = .create(_mfoo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .sequentiallyConsistent,
@@ -1501,7 +1501,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .sequentiallyConsistent,
@@ -1510,7 +1510,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .sequentiallyConsistent,
@@ -1519,7 +1519,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .sequentiallyConsistent,
@@ -1533,7 +1533,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>> = .create(_mfoo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .sequentiallyConsistent,
@@ -1542,7 +1542,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .sequentiallyConsistent,
@@ -1551,7 +1551,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .sequentiallyConsistent,
@@ -1560,7 +1560,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .sequentiallyConsistent,
@@ -1574,7 +1574,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>> = .create(_mfoo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .sequentiallyConsistent,
@@ -1583,7 +1583,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo1,
       desired: _mfoo2,
       successOrdering: .sequentiallyConsistent,
@@ -1592,7 +1592,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .sequentiallyConsistent,
@@ -1601,7 +1601,7 @@ class BasicAtomicMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: _mfoo1,
       successOrdering: .sequentiallyConsistent,

--- a/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicMutableRawPointerTests.swift
+++ b/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicMutableRawPointerTests.swift
@@ -989,7 +989,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer> = .create(_mraw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .relaxed,
@@ -998,7 +998,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .relaxed,
@@ -1007,7 +1007,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .relaxed,
@@ -1016,7 +1016,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .relaxed,
@@ -1030,7 +1030,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer> = .create(_mraw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .relaxed,
@@ -1039,7 +1039,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .relaxed,
@@ -1048,7 +1048,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .relaxed,
@@ -1057,7 +1057,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .relaxed,
@@ -1071,7 +1071,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer> = .create(_mraw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .relaxed,
@@ -1080,7 +1080,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .relaxed,
@@ -1089,7 +1089,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .relaxed,
@@ -1098,7 +1098,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .relaxed,
@@ -1112,7 +1112,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer> = .create(_mraw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .acquiring,
@@ -1121,7 +1121,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .acquiring,
@@ -1130,7 +1130,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .acquiring,
@@ -1139,7 +1139,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .acquiring,
@@ -1153,7 +1153,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer> = .create(_mraw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .acquiring,
@@ -1162,7 +1162,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .acquiring,
@@ -1171,7 +1171,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .acquiring,
@@ -1180,7 +1180,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .acquiring,
@@ -1194,7 +1194,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer> = .create(_mraw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .acquiring,
@@ -1203,7 +1203,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .acquiring,
@@ -1212,7 +1212,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .acquiring,
@@ -1221,7 +1221,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .acquiring,
@@ -1235,7 +1235,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer> = .create(_mraw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .releasing,
@@ -1244,7 +1244,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .releasing,
@@ -1253,7 +1253,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .releasing,
@@ -1262,7 +1262,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .releasing,
@@ -1276,7 +1276,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer> = .create(_mraw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .releasing,
@@ -1285,7 +1285,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .releasing,
@@ -1294,7 +1294,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .releasing,
@@ -1303,7 +1303,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .releasing,
@@ -1317,7 +1317,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer> = .create(_mraw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .releasing,
@@ -1326,7 +1326,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .releasing,
@@ -1335,7 +1335,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .releasing,
@@ -1344,7 +1344,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .releasing,
@@ -1358,7 +1358,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer> = .create(_mraw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .acquiringAndReleasing,
@@ -1367,7 +1367,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .acquiringAndReleasing,
@@ -1376,7 +1376,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .acquiringAndReleasing,
@@ -1385,7 +1385,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .acquiringAndReleasing,
@@ -1399,7 +1399,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer> = .create(_mraw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .acquiringAndReleasing,
@@ -1408,7 +1408,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .acquiringAndReleasing,
@@ -1417,7 +1417,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .acquiringAndReleasing,
@@ -1426,7 +1426,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .acquiringAndReleasing,
@@ -1440,7 +1440,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer> = .create(_mraw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .acquiringAndReleasing,
@@ -1449,7 +1449,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .acquiringAndReleasing,
@@ -1458,7 +1458,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .acquiringAndReleasing,
@@ -1467,7 +1467,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .acquiringAndReleasing,
@@ -1481,7 +1481,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer> = .create(_mraw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .sequentiallyConsistent,
@@ -1490,7 +1490,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .sequentiallyConsistent,
@@ -1499,7 +1499,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .sequentiallyConsistent,
@@ -1508,7 +1508,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .sequentiallyConsistent,
@@ -1522,7 +1522,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer> = .create(_mraw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .sequentiallyConsistent,
@@ -1531,7 +1531,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .sequentiallyConsistent,
@@ -1540,7 +1540,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .sequentiallyConsistent,
@@ -1549,7 +1549,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .sequentiallyConsistent,
@@ -1563,7 +1563,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer> = .create(_mraw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .sequentiallyConsistent,
@@ -1572,7 +1572,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw1,
       desired: _mraw2,
       successOrdering: .sequentiallyConsistent,
@@ -1581,7 +1581,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .sequentiallyConsistent,
@@ -1590,7 +1590,7 @@ class BasicAtomicMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: _mraw1,
       successOrdering: .sequentiallyConsistent,

--- a/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicOptionalMutablePointerTests.swift
+++ b/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicOptionalMutablePointerTests.swift
@@ -1000,7 +1000,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .relaxed,
@@ -1009,7 +1009,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .relaxed,
@@ -1018,7 +1018,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1027,7 +1027,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1041,7 +1041,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .relaxed,
@@ -1050,7 +1050,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .relaxed,
@@ -1059,7 +1059,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1068,7 +1068,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1082,7 +1082,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .relaxed,
@@ -1091,7 +1091,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .relaxed,
@@ -1100,7 +1100,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1109,7 +1109,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1123,7 +1123,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .acquiring,
@@ -1132,7 +1132,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .acquiring,
@@ -1141,7 +1141,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1150,7 +1150,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1164,7 +1164,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .acquiring,
@@ -1173,7 +1173,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .acquiring,
@@ -1182,7 +1182,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1191,7 +1191,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1205,7 +1205,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .acquiring,
@@ -1214,7 +1214,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .acquiring,
@@ -1223,7 +1223,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1232,7 +1232,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1246,7 +1246,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .releasing,
@@ -1255,7 +1255,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .releasing,
@@ -1264,7 +1264,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .releasing,
@@ -1273,7 +1273,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .releasing,
@@ -1287,7 +1287,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .releasing,
@@ -1296,7 +1296,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .releasing,
@@ -1305,7 +1305,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .releasing,
@@ -1314,7 +1314,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .releasing,
@@ -1328,7 +1328,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .releasing,
@@ -1337,7 +1337,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .releasing,
@@ -1346,7 +1346,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .releasing,
@@ -1355,7 +1355,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .releasing,
@@ -1369,7 +1369,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .acquiringAndReleasing,
@@ -1378,7 +1378,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .acquiringAndReleasing,
@@ -1387,7 +1387,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1396,7 +1396,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1410,7 +1410,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .acquiringAndReleasing,
@@ -1419,7 +1419,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .acquiringAndReleasing,
@@ -1428,7 +1428,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1437,7 +1437,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1451,7 +1451,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .acquiringAndReleasing,
@@ -1460,7 +1460,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .acquiringAndReleasing,
@@ -1469,7 +1469,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1478,7 +1478,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1492,7 +1492,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .sequentiallyConsistent,
@@ -1501,7 +1501,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .sequentiallyConsistent,
@@ -1510,7 +1510,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1519,7 +1519,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1533,7 +1533,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .sequentiallyConsistent,
@@ -1542,7 +1542,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .sequentiallyConsistent,
@@ -1551,7 +1551,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1560,7 +1560,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1574,7 +1574,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutablePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutablePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .sequentiallyConsistent,
@@ -1583,7 +1583,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mfoo2,
       successOrdering: .sequentiallyConsistent,
@@ -1592,7 +1592,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mfoo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1601,7 +1601,7 @@ class BasicAtomicOptionalMutablePointerTests: XCTestCase {
     XCTAssertEqual(original, _mfoo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mfoo2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,

--- a/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicOptionalMutableRawPointerTests.swift
+++ b/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicOptionalMutableRawPointerTests.swift
@@ -989,7 +989,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .relaxed,
@@ -998,7 +998,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .relaxed,
@@ -1007,7 +1007,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1016,7 +1016,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1030,7 +1030,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .relaxed,
@@ -1039,7 +1039,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .relaxed,
@@ -1048,7 +1048,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1057,7 +1057,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1071,7 +1071,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .relaxed,
@@ -1080,7 +1080,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .relaxed,
@@ -1089,7 +1089,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1098,7 +1098,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1112,7 +1112,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .acquiring,
@@ -1121,7 +1121,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .acquiring,
@@ -1130,7 +1130,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1139,7 +1139,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1153,7 +1153,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .acquiring,
@@ -1162,7 +1162,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .acquiring,
@@ -1171,7 +1171,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1180,7 +1180,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1194,7 +1194,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .acquiring,
@@ -1203,7 +1203,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .acquiring,
@@ -1212,7 +1212,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1221,7 +1221,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1235,7 +1235,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .releasing,
@@ -1244,7 +1244,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .releasing,
@@ -1253,7 +1253,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .releasing,
@@ -1262,7 +1262,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .releasing,
@@ -1276,7 +1276,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .releasing,
@@ -1285,7 +1285,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .releasing,
@@ -1294,7 +1294,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .releasing,
@@ -1303,7 +1303,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .releasing,
@@ -1317,7 +1317,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .releasing,
@@ -1326,7 +1326,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .releasing,
@@ -1335,7 +1335,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .releasing,
@@ -1344,7 +1344,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .releasing,
@@ -1358,7 +1358,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .acquiringAndReleasing,
@@ -1367,7 +1367,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .acquiringAndReleasing,
@@ -1376,7 +1376,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1385,7 +1385,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1399,7 +1399,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .acquiringAndReleasing,
@@ -1408,7 +1408,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .acquiringAndReleasing,
@@ -1417,7 +1417,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1426,7 +1426,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1440,7 +1440,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .acquiringAndReleasing,
@@ -1449,7 +1449,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .acquiringAndReleasing,
@@ -1458,7 +1458,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1467,7 +1467,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1481,7 +1481,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .sequentiallyConsistent,
@@ -1490,7 +1490,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .sequentiallyConsistent,
@@ -1499,7 +1499,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1508,7 +1508,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1522,7 +1522,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .sequentiallyConsistent,
@@ -1531,7 +1531,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .sequentiallyConsistent,
@@ -1540,7 +1540,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1549,7 +1549,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1563,7 +1563,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeMutableRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeMutableRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .sequentiallyConsistent,
@@ -1572,7 +1572,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _mraw2,
       successOrdering: .sequentiallyConsistent,
@@ -1581,7 +1581,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _mraw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1590,7 +1590,7 @@ class BasicAtomicOptionalMutableRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _mraw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _mraw2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,

--- a/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicOptionalPointerTests.swift
+++ b/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicOptionalPointerTests.swift
@@ -1000,7 +1000,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .relaxed,
@@ -1009,7 +1009,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .relaxed,
@@ -1018,7 +1018,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1027,7 +1027,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1041,7 +1041,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .relaxed,
@@ -1050,7 +1050,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .relaxed,
@@ -1059,7 +1059,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1068,7 +1068,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1082,7 +1082,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .relaxed,
@@ -1091,7 +1091,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .relaxed,
@@ -1100,7 +1100,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1109,7 +1109,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1123,7 +1123,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .acquiring,
@@ -1132,7 +1132,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .acquiring,
@@ -1141,7 +1141,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1150,7 +1150,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1164,7 +1164,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .acquiring,
@@ -1173,7 +1173,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .acquiring,
@@ -1182,7 +1182,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1191,7 +1191,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1205,7 +1205,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .acquiring,
@@ -1214,7 +1214,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .acquiring,
@@ -1223,7 +1223,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1232,7 +1232,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1246,7 +1246,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .releasing,
@@ -1255,7 +1255,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .releasing,
@@ -1264,7 +1264,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .releasing,
@@ -1273,7 +1273,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .releasing,
@@ -1287,7 +1287,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .releasing,
@@ -1296,7 +1296,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .releasing,
@@ -1305,7 +1305,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .releasing,
@@ -1314,7 +1314,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .releasing,
@@ -1328,7 +1328,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .releasing,
@@ -1337,7 +1337,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .releasing,
@@ -1346,7 +1346,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .releasing,
@@ -1355,7 +1355,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .releasing,
@@ -1369,7 +1369,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .acquiringAndReleasing,
@@ -1378,7 +1378,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .acquiringAndReleasing,
@@ -1387,7 +1387,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1396,7 +1396,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1410,7 +1410,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .acquiringAndReleasing,
@@ -1419,7 +1419,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .acquiringAndReleasing,
@@ -1428,7 +1428,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1437,7 +1437,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1451,7 +1451,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .acquiringAndReleasing,
@@ -1460,7 +1460,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .acquiringAndReleasing,
@@ -1469,7 +1469,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1478,7 +1478,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1492,7 +1492,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .sequentiallyConsistent,
@@ -1501,7 +1501,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .sequentiallyConsistent,
@@ -1510,7 +1510,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1519,7 +1519,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1533,7 +1533,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .sequentiallyConsistent,
@@ -1542,7 +1542,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .sequentiallyConsistent,
@@ -1551,7 +1551,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1560,7 +1560,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1574,7 +1574,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>?) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .sequentiallyConsistent,
@@ -1583,7 +1583,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _foo2,
       successOrdering: .sequentiallyConsistent,
@@ -1592,7 +1592,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1601,7 +1601,7 @@ class BasicAtomicOptionalPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,

--- a/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicOptionalRawPointerTests.swift
+++ b/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicOptionalRawPointerTests.swift
@@ -989,7 +989,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .relaxed,
@@ -998,7 +998,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .relaxed,
@@ -1007,7 +1007,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1016,7 +1016,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1030,7 +1030,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .relaxed,
@@ -1039,7 +1039,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .relaxed,
@@ -1048,7 +1048,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1057,7 +1057,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1071,7 +1071,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .relaxed,
@@ -1080,7 +1080,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .relaxed,
@@ -1089,7 +1089,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1098,7 +1098,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1112,7 +1112,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .acquiring,
@@ -1121,7 +1121,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .acquiring,
@@ -1130,7 +1130,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1139,7 +1139,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1153,7 +1153,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .acquiring,
@@ -1162,7 +1162,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .acquiring,
@@ -1171,7 +1171,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1180,7 +1180,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1194,7 +1194,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .acquiring,
@@ -1203,7 +1203,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .acquiring,
@@ -1212,7 +1212,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1221,7 +1221,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1235,7 +1235,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .releasing,
@@ -1244,7 +1244,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .releasing,
@@ -1253,7 +1253,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .releasing,
@@ -1262,7 +1262,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .releasing,
@@ -1276,7 +1276,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .releasing,
@@ -1285,7 +1285,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .releasing,
@@ -1294,7 +1294,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .releasing,
@@ -1303,7 +1303,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .releasing,
@@ -1317,7 +1317,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .releasing,
@@ -1326,7 +1326,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .releasing,
@@ -1335,7 +1335,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .releasing,
@@ -1344,7 +1344,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .releasing,
@@ -1358,7 +1358,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .acquiringAndReleasing,
@@ -1367,7 +1367,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .acquiringAndReleasing,
@@ -1376,7 +1376,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1385,7 +1385,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1399,7 +1399,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .acquiringAndReleasing,
@@ -1408,7 +1408,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .acquiringAndReleasing,
@@ -1417,7 +1417,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1426,7 +1426,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1440,7 +1440,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .acquiringAndReleasing,
@@ -1449,7 +1449,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .acquiringAndReleasing,
@@ -1458,7 +1458,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1467,7 +1467,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1481,7 +1481,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .sequentiallyConsistent,
@@ -1490,7 +1490,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .sequentiallyConsistent,
@@ -1499,7 +1499,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1508,7 +1508,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1522,7 +1522,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .sequentiallyConsistent,
@@ -1531,7 +1531,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .sequentiallyConsistent,
@@ -1540,7 +1540,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1549,7 +1549,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1563,7 +1563,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer?) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .sequentiallyConsistent,
@@ -1572,7 +1572,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _raw2,
       successOrdering: .sequentiallyConsistent,
@@ -1581,7 +1581,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1590,7 +1590,7 @@ class BasicAtomicOptionalRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,

--- a/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicOptionalReferenceTests.swift
+++ b/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicOptionalReferenceTests.swift
@@ -981,7 +981,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz?) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz?) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .relaxed,
@@ -990,7 +990,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .relaxed,
@@ -999,7 +999,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1008,7 +1008,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1022,7 +1022,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz?) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz?) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .relaxed,
@@ -1031,7 +1031,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .relaxed,
@@ -1040,7 +1040,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1049,7 +1049,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1063,7 +1063,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz?) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz?) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .relaxed,
@@ -1072,7 +1072,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .relaxed,
@@ -1081,7 +1081,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1090,7 +1090,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1104,7 +1104,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz?) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz?) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .acquiring,
@@ -1113,7 +1113,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .acquiring,
@@ -1122,7 +1122,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1131,7 +1131,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1145,7 +1145,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz?) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz?) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .acquiring,
@@ -1154,7 +1154,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .acquiring,
@@ -1163,7 +1163,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1172,7 +1172,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1186,7 +1186,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz?) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz?) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .acquiring,
@@ -1195,7 +1195,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .acquiring,
@@ -1204,7 +1204,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1213,7 +1213,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1227,7 +1227,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz?) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz?) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .releasing,
@@ -1236,7 +1236,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .releasing,
@@ -1245,7 +1245,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .releasing,
@@ -1254,7 +1254,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .releasing,
@@ -1268,7 +1268,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz?) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz?) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .releasing,
@@ -1277,7 +1277,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .releasing,
@@ -1286,7 +1286,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .releasing,
@@ -1295,7 +1295,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .releasing,
@@ -1309,7 +1309,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz?) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz?) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .releasing,
@@ -1318,7 +1318,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .releasing,
@@ -1327,7 +1327,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .releasing,
@@ -1336,7 +1336,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .releasing,
@@ -1350,7 +1350,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz?) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz?) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .acquiringAndReleasing,
@@ -1359,7 +1359,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .acquiringAndReleasing,
@@ -1368,7 +1368,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1377,7 +1377,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1391,7 +1391,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz?) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz?) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .acquiringAndReleasing,
@@ -1400,7 +1400,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .acquiringAndReleasing,
@@ -1409,7 +1409,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1418,7 +1418,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1432,7 +1432,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz?) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz?) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .acquiringAndReleasing,
@@ -1441,7 +1441,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .acquiringAndReleasing,
@@ -1450,7 +1450,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1459,7 +1459,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1473,7 +1473,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz?) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz?) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .sequentiallyConsistent,
@@ -1482,7 +1482,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .sequentiallyConsistent,
@@ -1491,7 +1491,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1500,7 +1500,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1514,7 +1514,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz?) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz?) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .sequentiallyConsistent,
@@ -1523,7 +1523,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .sequentiallyConsistent,
@@ -1532,7 +1532,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1541,7 +1541,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1555,7 +1555,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz?) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz?) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .sequentiallyConsistent,
@@ -1564,7 +1564,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _baz2,
       successOrdering: .sequentiallyConsistent,
@@ -1573,7 +1573,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1582,7 +1582,7 @@ class BasicAtomicOptionalReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,

--- a/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicOptionalUnmanagedTests.swift
+++ b/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicOptionalUnmanagedTests.swift
@@ -986,7 +986,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .relaxed,
@@ -995,7 +995,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .relaxed,
@@ -1004,7 +1004,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1013,7 +1013,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1027,7 +1027,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .relaxed,
@@ -1036,7 +1036,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .relaxed,
@@ -1045,7 +1045,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1054,7 +1054,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1068,7 +1068,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .relaxed,
@@ -1077,7 +1077,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .relaxed,
@@ -1086,7 +1086,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1095,7 +1095,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .relaxed,
@@ -1109,7 +1109,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .acquiring,
@@ -1118,7 +1118,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .acquiring,
@@ -1127,7 +1127,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1136,7 +1136,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1150,7 +1150,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .acquiring,
@@ -1159,7 +1159,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .acquiring,
@@ -1168,7 +1168,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1177,7 +1177,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1191,7 +1191,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .acquiring,
@@ -1200,7 +1200,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .acquiring,
@@ -1209,7 +1209,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1218,7 +1218,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .acquiring,
@@ -1232,7 +1232,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .releasing,
@@ -1241,7 +1241,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .releasing,
@@ -1250,7 +1250,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .releasing,
@@ -1259,7 +1259,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .releasing,
@@ -1273,7 +1273,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .releasing,
@@ -1282,7 +1282,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .releasing,
@@ -1291,7 +1291,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .releasing,
@@ -1300,7 +1300,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .releasing,
@@ -1314,7 +1314,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .releasing,
@@ -1323,7 +1323,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .releasing,
@@ -1332,7 +1332,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .releasing,
@@ -1341,7 +1341,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .releasing,
@@ -1355,7 +1355,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .acquiringAndReleasing,
@@ -1364,7 +1364,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .acquiringAndReleasing,
@@ -1373,7 +1373,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1382,7 +1382,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1396,7 +1396,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .acquiringAndReleasing,
@@ -1405,7 +1405,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .acquiringAndReleasing,
@@ -1414,7 +1414,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1423,7 +1423,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1437,7 +1437,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .acquiringAndReleasing,
@@ -1446,7 +1446,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .acquiringAndReleasing,
@@ -1455,7 +1455,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1464,7 +1464,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .acquiringAndReleasing,
@@ -1478,7 +1478,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .sequentiallyConsistent,
@@ -1487,7 +1487,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .sequentiallyConsistent,
@@ -1496,7 +1496,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1505,7 +1505,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1519,7 +1519,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .sequentiallyConsistent,
@@ -1528,7 +1528,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .sequentiallyConsistent,
@@ -1537,7 +1537,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1546,7 +1546,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1560,7 +1560,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>?> = .create(nil)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>?) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .sequentiallyConsistent,
@@ -1569,7 +1569,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, nil)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: nil,
       desired: _bar2,
       successOrdering: .sequentiallyConsistent,
@@ -1578,7 +1578,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,
@@ -1587,7 +1587,7 @@ class BasicAtomicOptionalUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), nil)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: nil,
       successOrdering: .sequentiallyConsistent,

--- a/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicPointerTests.swift
+++ b/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicPointerTests.swift
@@ -1000,7 +1000,7 @@ class BasicAtomicPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>> = .create(_foo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .relaxed,
@@ -1009,7 +1009,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .relaxed,
@@ -1018,7 +1018,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .relaxed,
@@ -1027,7 +1027,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .relaxed,
@@ -1041,7 +1041,7 @@ class BasicAtomicPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>> = .create(_foo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .relaxed,
@@ -1050,7 +1050,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .relaxed,
@@ -1059,7 +1059,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .relaxed,
@@ -1068,7 +1068,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .relaxed,
@@ -1082,7 +1082,7 @@ class BasicAtomicPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>> = .create(_foo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .relaxed,
@@ -1091,7 +1091,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .relaxed,
@@ -1100,7 +1100,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .relaxed,
@@ -1109,7 +1109,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .relaxed,
@@ -1123,7 +1123,7 @@ class BasicAtomicPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>> = .create(_foo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .acquiring,
@@ -1132,7 +1132,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .acquiring,
@@ -1141,7 +1141,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .acquiring,
@@ -1150,7 +1150,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .acquiring,
@@ -1164,7 +1164,7 @@ class BasicAtomicPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>> = .create(_foo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .acquiring,
@@ -1173,7 +1173,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .acquiring,
@@ -1182,7 +1182,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .acquiring,
@@ -1191,7 +1191,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .acquiring,
@@ -1205,7 +1205,7 @@ class BasicAtomicPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>> = .create(_foo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .acquiring,
@@ -1214,7 +1214,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .acquiring,
@@ -1223,7 +1223,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .acquiring,
@@ -1232,7 +1232,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .acquiring,
@@ -1246,7 +1246,7 @@ class BasicAtomicPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>> = .create(_foo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .releasing,
@@ -1255,7 +1255,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .releasing,
@@ -1264,7 +1264,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .releasing,
@@ -1273,7 +1273,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .releasing,
@@ -1287,7 +1287,7 @@ class BasicAtomicPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>> = .create(_foo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .releasing,
@@ -1296,7 +1296,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .releasing,
@@ -1305,7 +1305,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .releasing,
@@ -1314,7 +1314,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .releasing,
@@ -1328,7 +1328,7 @@ class BasicAtomicPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>> = .create(_foo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .releasing,
@@ -1337,7 +1337,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .releasing,
@@ -1346,7 +1346,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .releasing,
@@ -1355,7 +1355,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .releasing,
@@ -1369,7 +1369,7 @@ class BasicAtomicPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>> = .create(_foo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .acquiringAndReleasing,
@@ -1378,7 +1378,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .acquiringAndReleasing,
@@ -1387,7 +1387,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .acquiringAndReleasing,
@@ -1396,7 +1396,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .acquiringAndReleasing,
@@ -1410,7 +1410,7 @@ class BasicAtomicPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>> = .create(_foo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .acquiringAndReleasing,
@@ -1419,7 +1419,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .acquiringAndReleasing,
@@ -1428,7 +1428,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .acquiringAndReleasing,
@@ -1437,7 +1437,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .acquiringAndReleasing,
@@ -1451,7 +1451,7 @@ class BasicAtomicPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>> = .create(_foo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .acquiringAndReleasing,
@@ -1460,7 +1460,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .acquiringAndReleasing,
@@ -1469,7 +1469,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .acquiringAndReleasing,
@@ -1478,7 +1478,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .acquiringAndReleasing,
@@ -1492,7 +1492,7 @@ class BasicAtomicPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>> = .create(_foo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .sequentiallyConsistent,
@@ -1501,7 +1501,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .sequentiallyConsistent,
@@ -1510,7 +1510,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .sequentiallyConsistent,
@@ -1519,7 +1519,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .sequentiallyConsistent,
@@ -1533,7 +1533,7 @@ class BasicAtomicPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>> = .create(_foo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .sequentiallyConsistent,
@@ -1542,7 +1542,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .sequentiallyConsistent,
@@ -1551,7 +1551,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .sequentiallyConsistent,
@@ -1560,7 +1560,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .sequentiallyConsistent,
@@ -1574,7 +1574,7 @@ class BasicAtomicPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafePointer<Foo>> = .create(_foo1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafePointer<Foo>) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .sequentiallyConsistent,
@@ -1583,7 +1583,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo1)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo1,
       desired: _foo2,
       successOrdering: .sequentiallyConsistent,
@@ -1592,7 +1592,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .sequentiallyConsistent,
@@ -1601,7 +1601,7 @@ class BasicAtomicPointerTests: XCTestCase {
     XCTAssertEqual(original, _foo2)
     XCTAssertEqual(v.load(ordering: .relaxed), _foo1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _foo2,
       desired: _foo1,
       successOrdering: .sequentiallyConsistent,

--- a/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicRawPointerTests.swift
+++ b/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicRawPointerTests.swift
@@ -989,7 +989,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer> = .create(_raw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .relaxed,
@@ -998,7 +998,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .relaxed,
@@ -1007,7 +1007,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .relaxed,
@@ -1016,7 +1016,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .relaxed,
@@ -1030,7 +1030,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer> = .create(_raw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .relaxed,
@@ -1039,7 +1039,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .relaxed,
@@ -1048,7 +1048,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .relaxed,
@@ -1057,7 +1057,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .relaxed,
@@ -1071,7 +1071,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer> = .create(_raw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .relaxed,
@@ -1080,7 +1080,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .relaxed,
@@ -1089,7 +1089,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .relaxed,
@@ -1098,7 +1098,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .relaxed,
@@ -1112,7 +1112,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer> = .create(_raw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .acquiring,
@@ -1121,7 +1121,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .acquiring,
@@ -1130,7 +1130,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .acquiring,
@@ -1139,7 +1139,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .acquiring,
@@ -1153,7 +1153,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer> = .create(_raw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .acquiring,
@@ -1162,7 +1162,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .acquiring,
@@ -1171,7 +1171,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .acquiring,
@@ -1180,7 +1180,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .acquiring,
@@ -1194,7 +1194,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer> = .create(_raw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .acquiring,
@@ -1203,7 +1203,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .acquiring,
@@ -1212,7 +1212,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .acquiring,
@@ -1221,7 +1221,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .acquiring,
@@ -1235,7 +1235,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer> = .create(_raw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .releasing,
@@ -1244,7 +1244,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .releasing,
@@ -1253,7 +1253,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .releasing,
@@ -1262,7 +1262,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .releasing,
@@ -1276,7 +1276,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer> = .create(_raw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .releasing,
@@ -1285,7 +1285,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .releasing,
@@ -1294,7 +1294,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .releasing,
@@ -1303,7 +1303,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .releasing,
@@ -1317,7 +1317,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer> = .create(_raw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .releasing,
@@ -1326,7 +1326,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .releasing,
@@ -1335,7 +1335,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .releasing,
@@ -1344,7 +1344,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .releasing,
@@ -1358,7 +1358,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer> = .create(_raw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .acquiringAndReleasing,
@@ -1367,7 +1367,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .acquiringAndReleasing,
@@ -1376,7 +1376,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .acquiringAndReleasing,
@@ -1385,7 +1385,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .acquiringAndReleasing,
@@ -1399,7 +1399,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer> = .create(_raw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .acquiringAndReleasing,
@@ -1408,7 +1408,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .acquiringAndReleasing,
@@ -1417,7 +1417,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .acquiringAndReleasing,
@@ -1426,7 +1426,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .acquiringAndReleasing,
@@ -1440,7 +1440,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer> = .create(_raw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .acquiringAndReleasing,
@@ -1449,7 +1449,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .acquiringAndReleasing,
@@ -1458,7 +1458,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .acquiringAndReleasing,
@@ -1467,7 +1467,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .acquiringAndReleasing,
@@ -1481,7 +1481,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer> = .create(_raw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .sequentiallyConsistent,
@@ -1490,7 +1490,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .sequentiallyConsistent,
@@ -1499,7 +1499,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .sequentiallyConsistent,
@@ -1508,7 +1508,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .sequentiallyConsistent,
@@ -1522,7 +1522,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer> = .create(_raw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .sequentiallyConsistent,
@@ -1531,7 +1531,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .sequentiallyConsistent,
@@ -1540,7 +1540,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .sequentiallyConsistent,
@@ -1549,7 +1549,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .sequentiallyConsistent,
@@ -1563,7 +1563,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     let v: UnsafeAtomic<UnsafeRawPointer> = .create(_raw1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UnsafeRawPointer) = v.compareExchange(
+    var (exchanged, original): (Bool, UnsafeRawPointer) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .sequentiallyConsistent,
@@ -1572,7 +1572,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw1)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw1,
       desired: _raw2,
       successOrdering: .sequentiallyConsistent,
@@ -1581,7 +1581,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .sequentiallyConsistent,
@@ -1590,7 +1590,7 @@ class BasicAtomicRawPointerTests: XCTestCase {
     XCTAssertEqual(original, _raw2)
     XCTAssertEqual(v.load(ordering: .relaxed), _raw1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _raw2,
       desired: _raw1,
       successOrdering: .sequentiallyConsistent,

--- a/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicRawRepresentableTests.swift
+++ b/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicRawRepresentableTests.swift
@@ -979,7 +979,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     let v: UnsafeAtomic<Fred> = .create(Fred.one)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Fred) = v.compareExchange(
+    var (exchanged, original): (Bool, Fred) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .relaxed,
@@ -988,7 +988,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.one)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .relaxed,
@@ -997,7 +997,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .relaxed,
@@ -1006,7 +1006,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.one)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .relaxed,
@@ -1020,7 +1020,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     let v: UnsafeAtomic<Fred> = .create(Fred.one)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Fred) = v.compareExchange(
+    var (exchanged, original): (Bool, Fred) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .relaxed,
@@ -1029,7 +1029,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.one)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .relaxed,
@@ -1038,7 +1038,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .relaxed,
@@ -1047,7 +1047,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.one)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .relaxed,
@@ -1061,7 +1061,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     let v: UnsafeAtomic<Fred> = .create(Fred.one)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Fred) = v.compareExchange(
+    var (exchanged, original): (Bool, Fred) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .relaxed,
@@ -1070,7 +1070,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.one)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .relaxed,
@@ -1079,7 +1079,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .relaxed,
@@ -1088,7 +1088,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.one)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .relaxed,
@@ -1102,7 +1102,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     let v: UnsafeAtomic<Fred> = .create(Fred.one)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Fred) = v.compareExchange(
+    var (exchanged, original): (Bool, Fred) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .acquiring,
@@ -1111,7 +1111,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.one)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .acquiring,
@@ -1120,7 +1120,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .acquiring,
@@ -1129,7 +1129,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.one)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .acquiring,
@@ -1143,7 +1143,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     let v: UnsafeAtomic<Fred> = .create(Fred.one)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Fred) = v.compareExchange(
+    var (exchanged, original): (Bool, Fred) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .acquiring,
@@ -1152,7 +1152,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.one)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .acquiring,
@@ -1161,7 +1161,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .acquiring,
@@ -1170,7 +1170,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.one)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .acquiring,
@@ -1184,7 +1184,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     let v: UnsafeAtomic<Fred> = .create(Fred.one)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Fred) = v.compareExchange(
+    var (exchanged, original): (Bool, Fred) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .acquiring,
@@ -1193,7 +1193,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.one)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .acquiring,
@@ -1202,7 +1202,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .acquiring,
@@ -1211,7 +1211,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.one)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .acquiring,
@@ -1225,7 +1225,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     let v: UnsafeAtomic<Fred> = .create(Fred.one)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Fred) = v.compareExchange(
+    var (exchanged, original): (Bool, Fred) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .releasing,
@@ -1234,7 +1234,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.one)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .releasing,
@@ -1243,7 +1243,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .releasing,
@@ -1252,7 +1252,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.one)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .releasing,
@@ -1266,7 +1266,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     let v: UnsafeAtomic<Fred> = .create(Fred.one)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Fred) = v.compareExchange(
+    var (exchanged, original): (Bool, Fred) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .releasing,
@@ -1275,7 +1275,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.one)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .releasing,
@@ -1284,7 +1284,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .releasing,
@@ -1293,7 +1293,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.one)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .releasing,
@@ -1307,7 +1307,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     let v: UnsafeAtomic<Fred> = .create(Fred.one)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Fred) = v.compareExchange(
+    var (exchanged, original): (Bool, Fred) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .releasing,
@@ -1316,7 +1316,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.one)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .releasing,
@@ -1325,7 +1325,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .releasing,
@@ -1334,7 +1334,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.one)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .releasing,
@@ -1348,7 +1348,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     let v: UnsafeAtomic<Fred> = .create(Fred.one)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Fred) = v.compareExchange(
+    var (exchanged, original): (Bool, Fred) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .acquiringAndReleasing,
@@ -1357,7 +1357,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.one)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .acquiringAndReleasing,
@@ -1366,7 +1366,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .acquiringAndReleasing,
@@ -1375,7 +1375,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.one)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .acquiringAndReleasing,
@@ -1389,7 +1389,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     let v: UnsafeAtomic<Fred> = .create(Fred.one)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Fred) = v.compareExchange(
+    var (exchanged, original): (Bool, Fred) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .acquiringAndReleasing,
@@ -1398,7 +1398,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.one)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .acquiringAndReleasing,
@@ -1407,7 +1407,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .acquiringAndReleasing,
@@ -1416,7 +1416,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.one)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .acquiringAndReleasing,
@@ -1430,7 +1430,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     let v: UnsafeAtomic<Fred> = .create(Fred.one)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Fred) = v.compareExchange(
+    var (exchanged, original): (Bool, Fred) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .acquiringAndReleasing,
@@ -1439,7 +1439,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.one)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .acquiringAndReleasing,
@@ -1448,7 +1448,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .acquiringAndReleasing,
@@ -1457,7 +1457,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.one)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .acquiringAndReleasing,
@@ -1471,7 +1471,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     let v: UnsafeAtomic<Fred> = .create(Fred.one)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Fred) = v.compareExchange(
+    var (exchanged, original): (Bool, Fred) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .sequentiallyConsistent,
@@ -1480,7 +1480,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.one)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .sequentiallyConsistent,
@@ -1489,7 +1489,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .sequentiallyConsistent,
@@ -1498,7 +1498,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.one)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .sequentiallyConsistent,
@@ -1512,7 +1512,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     let v: UnsafeAtomic<Fred> = .create(Fred.one)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Fred) = v.compareExchange(
+    var (exchanged, original): (Bool, Fred) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .sequentiallyConsistent,
@@ -1521,7 +1521,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.one)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .sequentiallyConsistent,
@@ -1530,7 +1530,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .sequentiallyConsistent,
@@ -1539,7 +1539,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.one)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .sequentiallyConsistent,
@@ -1553,7 +1553,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     let v: UnsafeAtomic<Fred> = .create(Fred.one)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Fred) = v.compareExchange(
+    var (exchanged, original): (Bool, Fred) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .sequentiallyConsistent,
@@ -1562,7 +1562,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.one)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.one,
       desired: Fred.two,
       successOrdering: .sequentiallyConsistent,
@@ -1571,7 +1571,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.two)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .sequentiallyConsistent,
@@ -1580,7 +1580,7 @@ class BasicAtomicRawRepresentableTests: XCTestCase {
     XCTAssertEqual(original, Fred.two)
     XCTAssertEqual(v.load(ordering: .relaxed), Fred.one)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: Fred.two,
       desired: Fred.one,
       successOrdering: .sequentiallyConsistent,

--- a/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicReferenceTests.swift
+++ b/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicReferenceTests.swift
@@ -981,7 +981,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz> = .create(_baz1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .relaxed,
@@ -990,7 +990,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz1)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .relaxed,
@@ -999,7 +999,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .relaxed,
@@ -1008,7 +1008,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .relaxed,
@@ -1022,7 +1022,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz> = .create(_baz1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .relaxed,
@@ -1031,7 +1031,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz1)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .relaxed,
@@ -1040,7 +1040,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .relaxed,
@@ -1049,7 +1049,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .relaxed,
@@ -1063,7 +1063,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz> = .create(_baz1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .relaxed,
@@ -1072,7 +1072,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz1)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .relaxed,
@@ -1081,7 +1081,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .relaxed,
@@ -1090,7 +1090,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .relaxed,
@@ -1104,7 +1104,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz> = .create(_baz1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .acquiring,
@@ -1113,7 +1113,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz1)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .acquiring,
@@ -1122,7 +1122,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .acquiring,
@@ -1131,7 +1131,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .acquiring,
@@ -1145,7 +1145,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz> = .create(_baz1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .acquiring,
@@ -1154,7 +1154,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz1)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .acquiring,
@@ -1163,7 +1163,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .acquiring,
@@ -1172,7 +1172,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .acquiring,
@@ -1186,7 +1186,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz> = .create(_baz1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .acquiring,
@@ -1195,7 +1195,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz1)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .acquiring,
@@ -1204,7 +1204,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .acquiring,
@@ -1213,7 +1213,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .acquiring,
@@ -1227,7 +1227,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz> = .create(_baz1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .releasing,
@@ -1236,7 +1236,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz1)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .releasing,
@@ -1245,7 +1245,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .releasing,
@@ -1254,7 +1254,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .releasing,
@@ -1268,7 +1268,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz> = .create(_baz1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .releasing,
@@ -1277,7 +1277,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz1)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .releasing,
@@ -1286,7 +1286,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .releasing,
@@ -1295,7 +1295,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .releasing,
@@ -1309,7 +1309,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz> = .create(_baz1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .releasing,
@@ -1318,7 +1318,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz1)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .releasing,
@@ -1327,7 +1327,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .releasing,
@@ -1336,7 +1336,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .releasing,
@@ -1350,7 +1350,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz> = .create(_baz1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .acquiringAndReleasing,
@@ -1359,7 +1359,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz1)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .acquiringAndReleasing,
@@ -1368,7 +1368,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .acquiringAndReleasing,
@@ -1377,7 +1377,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .acquiringAndReleasing,
@@ -1391,7 +1391,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz> = .create(_baz1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .acquiringAndReleasing,
@@ -1400,7 +1400,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz1)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .acquiringAndReleasing,
@@ -1409,7 +1409,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .acquiringAndReleasing,
@@ -1418,7 +1418,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .acquiringAndReleasing,
@@ -1432,7 +1432,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz> = .create(_baz1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .acquiringAndReleasing,
@@ -1441,7 +1441,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz1)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .acquiringAndReleasing,
@@ -1450,7 +1450,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .acquiringAndReleasing,
@@ -1459,7 +1459,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .acquiringAndReleasing,
@@ -1473,7 +1473,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz> = .create(_baz1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .sequentiallyConsistent,
@@ -1482,7 +1482,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz1)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .sequentiallyConsistent,
@@ -1491,7 +1491,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .sequentiallyConsistent,
@@ -1500,7 +1500,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .sequentiallyConsistent,
@@ -1514,7 +1514,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz> = .create(_baz1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .sequentiallyConsistent,
@@ -1523,7 +1523,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz1)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .sequentiallyConsistent,
@@ -1532,7 +1532,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .sequentiallyConsistent,
@@ -1541,7 +1541,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .sequentiallyConsistent,
@@ -1555,7 +1555,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     let v: UnsafeAtomic<Baz> = .create(_baz1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Baz) = v.compareExchange(
+    var (exchanged, original): (Bool, Baz) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .sequentiallyConsistent,
@@ -1564,7 +1564,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz1)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz1,
       desired: _baz2,
       successOrdering: .sequentiallyConsistent,
@@ -1573,7 +1573,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .sequentiallyConsistent,
@@ -1582,7 +1582,7 @@ class BasicAtomicReferenceTests: XCTestCase {
     XCTAssertEqual(original, _baz2)
     XCTAssertEqual(v.load(ordering: .relaxed), _baz1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _baz2,
       desired: _baz1,
       successOrdering: .sequentiallyConsistent,

--- a/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicUInt16Tests.swift
+++ b/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicUInt16Tests.swift
@@ -979,7 +979,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     let v: UnsafeAtomic<UInt16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt16) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -988,7 +988,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -997,7 +997,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1006,7 +1006,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1020,7 +1020,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     let v: UnsafeAtomic<UInt16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt16) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1029,7 +1029,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1038,7 +1038,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1047,7 +1047,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1061,7 +1061,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     let v: UnsafeAtomic<UInt16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt16) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1070,7 +1070,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1079,7 +1079,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1088,7 +1088,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1102,7 +1102,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     let v: UnsafeAtomic<UInt16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt16) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1111,7 +1111,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1120,7 +1120,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1129,7 +1129,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1143,7 +1143,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     let v: UnsafeAtomic<UInt16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt16) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1152,7 +1152,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1161,7 +1161,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1170,7 +1170,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1184,7 +1184,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     let v: UnsafeAtomic<UInt16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt16) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1193,7 +1193,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1202,7 +1202,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1211,7 +1211,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1225,7 +1225,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     let v: UnsafeAtomic<UInt16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt16) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1234,7 +1234,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1243,7 +1243,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1252,7 +1252,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1266,7 +1266,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     let v: UnsafeAtomic<UInt16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt16) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1275,7 +1275,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1284,7 +1284,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1293,7 +1293,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1307,7 +1307,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     let v: UnsafeAtomic<UInt16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt16) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1316,7 +1316,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1325,7 +1325,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1334,7 +1334,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1348,7 +1348,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     let v: UnsafeAtomic<UInt16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt16) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1357,7 +1357,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1366,7 +1366,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1375,7 +1375,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1389,7 +1389,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     let v: UnsafeAtomic<UInt16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt16) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1398,7 +1398,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1407,7 +1407,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1416,7 +1416,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1430,7 +1430,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     let v: UnsafeAtomic<UInt16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt16) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1439,7 +1439,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1448,7 +1448,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1457,7 +1457,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1471,7 +1471,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     let v: UnsafeAtomic<UInt16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt16) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1480,7 +1480,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1489,7 +1489,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1498,7 +1498,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1512,7 +1512,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     let v: UnsafeAtomic<UInt16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt16) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1521,7 +1521,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1530,7 +1530,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1539,7 +1539,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1553,7 +1553,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     let v: UnsafeAtomic<UInt16> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt16) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt16) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1562,7 +1562,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1571,7 +1571,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1580,7 +1580,7 @@ class BasicAtomicUInt16Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,

--- a/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicUInt32Tests.swift
+++ b/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicUInt32Tests.swift
@@ -979,7 +979,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     let v: UnsafeAtomic<UInt32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt32) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -988,7 +988,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -997,7 +997,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1006,7 +1006,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1020,7 +1020,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     let v: UnsafeAtomic<UInt32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt32) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1029,7 +1029,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1038,7 +1038,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1047,7 +1047,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1061,7 +1061,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     let v: UnsafeAtomic<UInt32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt32) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1070,7 +1070,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1079,7 +1079,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1088,7 +1088,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1102,7 +1102,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     let v: UnsafeAtomic<UInt32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt32) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1111,7 +1111,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1120,7 +1120,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1129,7 +1129,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1143,7 +1143,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     let v: UnsafeAtomic<UInt32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt32) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1152,7 +1152,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1161,7 +1161,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1170,7 +1170,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1184,7 +1184,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     let v: UnsafeAtomic<UInt32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt32) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1193,7 +1193,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1202,7 +1202,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1211,7 +1211,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1225,7 +1225,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     let v: UnsafeAtomic<UInt32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt32) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1234,7 +1234,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1243,7 +1243,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1252,7 +1252,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1266,7 +1266,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     let v: UnsafeAtomic<UInt32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt32) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1275,7 +1275,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1284,7 +1284,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1293,7 +1293,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1307,7 +1307,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     let v: UnsafeAtomic<UInt32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt32) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1316,7 +1316,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1325,7 +1325,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1334,7 +1334,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1348,7 +1348,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     let v: UnsafeAtomic<UInt32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt32) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1357,7 +1357,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1366,7 +1366,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1375,7 +1375,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1389,7 +1389,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     let v: UnsafeAtomic<UInt32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt32) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1398,7 +1398,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1407,7 +1407,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1416,7 +1416,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1430,7 +1430,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     let v: UnsafeAtomic<UInt32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt32) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1439,7 +1439,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1448,7 +1448,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1457,7 +1457,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1471,7 +1471,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     let v: UnsafeAtomic<UInt32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt32) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1480,7 +1480,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1489,7 +1489,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1498,7 +1498,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1512,7 +1512,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     let v: UnsafeAtomic<UInt32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt32) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1521,7 +1521,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1530,7 +1530,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1539,7 +1539,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1553,7 +1553,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     let v: UnsafeAtomic<UInt32> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt32) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt32) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1562,7 +1562,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1571,7 +1571,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1580,7 +1580,7 @@ class BasicAtomicUInt32Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,

--- a/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicUInt64Tests.swift
+++ b/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicUInt64Tests.swift
@@ -979,7 +979,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     let v: UnsafeAtomic<UInt64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt64) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -988,7 +988,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -997,7 +997,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1006,7 +1006,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1020,7 +1020,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     let v: UnsafeAtomic<UInt64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt64) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1029,7 +1029,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1038,7 +1038,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1047,7 +1047,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1061,7 +1061,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     let v: UnsafeAtomic<UInt64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt64) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1070,7 +1070,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1079,7 +1079,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1088,7 +1088,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1102,7 +1102,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     let v: UnsafeAtomic<UInt64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt64) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1111,7 +1111,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1120,7 +1120,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1129,7 +1129,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1143,7 +1143,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     let v: UnsafeAtomic<UInt64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt64) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1152,7 +1152,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1161,7 +1161,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1170,7 +1170,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1184,7 +1184,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     let v: UnsafeAtomic<UInt64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt64) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1193,7 +1193,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1202,7 +1202,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1211,7 +1211,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1225,7 +1225,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     let v: UnsafeAtomic<UInt64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt64) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1234,7 +1234,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1243,7 +1243,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1252,7 +1252,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1266,7 +1266,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     let v: UnsafeAtomic<UInt64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt64) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1275,7 +1275,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1284,7 +1284,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1293,7 +1293,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1307,7 +1307,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     let v: UnsafeAtomic<UInt64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt64) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1316,7 +1316,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1325,7 +1325,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1334,7 +1334,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1348,7 +1348,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     let v: UnsafeAtomic<UInt64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt64) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1357,7 +1357,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1366,7 +1366,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1375,7 +1375,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1389,7 +1389,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     let v: UnsafeAtomic<UInt64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt64) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1398,7 +1398,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1407,7 +1407,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1416,7 +1416,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1430,7 +1430,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     let v: UnsafeAtomic<UInt64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt64) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1439,7 +1439,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1448,7 +1448,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1457,7 +1457,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1471,7 +1471,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     let v: UnsafeAtomic<UInt64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt64) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1480,7 +1480,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1489,7 +1489,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1498,7 +1498,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1512,7 +1512,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     let v: UnsafeAtomic<UInt64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt64) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1521,7 +1521,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1530,7 +1530,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1539,7 +1539,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1553,7 +1553,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     let v: UnsafeAtomic<UInt64> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt64) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt64) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1562,7 +1562,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1571,7 +1571,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1580,7 +1580,7 @@ class BasicAtomicUInt64Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,

--- a/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicUInt8Tests.swift
+++ b/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicUInt8Tests.swift
@@ -979,7 +979,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     let v: UnsafeAtomic<UInt8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt8) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -988,7 +988,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -997,7 +997,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1006,7 +1006,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1020,7 +1020,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     let v: UnsafeAtomic<UInt8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt8) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1029,7 +1029,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1038,7 +1038,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1047,7 +1047,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1061,7 +1061,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     let v: UnsafeAtomic<UInt8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt8) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1070,7 +1070,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1079,7 +1079,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1088,7 +1088,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1102,7 +1102,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     let v: UnsafeAtomic<UInt8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt8) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1111,7 +1111,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1120,7 +1120,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1129,7 +1129,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1143,7 +1143,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     let v: UnsafeAtomic<UInt8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt8) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1152,7 +1152,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1161,7 +1161,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1170,7 +1170,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1184,7 +1184,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     let v: UnsafeAtomic<UInt8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt8) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1193,7 +1193,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1202,7 +1202,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1211,7 +1211,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1225,7 +1225,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     let v: UnsafeAtomic<UInt8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt8) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1234,7 +1234,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1243,7 +1243,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1252,7 +1252,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1266,7 +1266,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     let v: UnsafeAtomic<UInt8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt8) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1275,7 +1275,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1284,7 +1284,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1293,7 +1293,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1307,7 +1307,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     let v: UnsafeAtomic<UInt8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt8) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1316,7 +1316,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1325,7 +1325,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1334,7 +1334,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1348,7 +1348,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     let v: UnsafeAtomic<UInt8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt8) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1357,7 +1357,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1366,7 +1366,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1375,7 +1375,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1389,7 +1389,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     let v: UnsafeAtomic<UInt8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt8) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1398,7 +1398,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1407,7 +1407,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1416,7 +1416,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1430,7 +1430,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     let v: UnsafeAtomic<UInt8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt8) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1439,7 +1439,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1448,7 +1448,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1457,7 +1457,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1471,7 +1471,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     let v: UnsafeAtomic<UInt8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt8) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1480,7 +1480,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1489,7 +1489,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1498,7 +1498,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1512,7 +1512,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     let v: UnsafeAtomic<UInt8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt8) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1521,7 +1521,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1530,7 +1530,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1539,7 +1539,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1553,7 +1553,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     let v: UnsafeAtomic<UInt8> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt8) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt8) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1562,7 +1562,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1571,7 +1571,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1580,7 +1580,7 @@ class BasicAtomicUInt8Tests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,

--- a/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicUIntTests.swift
+++ b/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicUIntTests.swift
@@ -979,7 +979,7 @@ class BasicAtomicUIntTests: XCTestCase {
     let v: UnsafeAtomic<UInt> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -988,7 +988,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -997,7 +997,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1006,7 +1006,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1020,7 +1020,7 @@ class BasicAtomicUIntTests: XCTestCase {
     let v: UnsafeAtomic<UInt> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1029,7 +1029,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1038,7 +1038,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1047,7 +1047,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1061,7 +1061,7 @@ class BasicAtomicUIntTests: XCTestCase {
     let v: UnsafeAtomic<UInt> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1070,7 +1070,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .relaxed,
@@ -1079,7 +1079,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1088,7 +1088,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .relaxed,
@@ -1102,7 +1102,7 @@ class BasicAtomicUIntTests: XCTestCase {
     let v: UnsafeAtomic<UInt> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1111,7 +1111,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1120,7 +1120,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1129,7 +1129,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1143,7 +1143,7 @@ class BasicAtomicUIntTests: XCTestCase {
     let v: UnsafeAtomic<UInt> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1152,7 +1152,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1161,7 +1161,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1170,7 +1170,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1184,7 +1184,7 @@ class BasicAtomicUIntTests: XCTestCase {
     let v: UnsafeAtomic<UInt> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1193,7 +1193,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiring,
@@ -1202,7 +1202,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1211,7 +1211,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiring,
@@ -1225,7 +1225,7 @@ class BasicAtomicUIntTests: XCTestCase {
     let v: UnsafeAtomic<UInt> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1234,7 +1234,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1243,7 +1243,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1252,7 +1252,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1266,7 +1266,7 @@ class BasicAtomicUIntTests: XCTestCase {
     let v: UnsafeAtomic<UInt> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1275,7 +1275,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1284,7 +1284,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1293,7 +1293,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1307,7 +1307,7 @@ class BasicAtomicUIntTests: XCTestCase {
     let v: UnsafeAtomic<UInt> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1316,7 +1316,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .releasing,
@@ -1325,7 +1325,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1334,7 +1334,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .releasing,
@@ -1348,7 +1348,7 @@ class BasicAtomicUIntTests: XCTestCase {
     let v: UnsafeAtomic<UInt> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1357,7 +1357,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1366,7 +1366,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1375,7 +1375,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1389,7 +1389,7 @@ class BasicAtomicUIntTests: XCTestCase {
     let v: UnsafeAtomic<UInt> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1398,7 +1398,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1407,7 +1407,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1416,7 +1416,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1430,7 +1430,7 @@ class BasicAtomicUIntTests: XCTestCase {
     let v: UnsafeAtomic<UInt> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1439,7 +1439,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .acquiringAndReleasing,
@@ -1448,7 +1448,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1457,7 +1457,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .acquiringAndReleasing,
@@ -1471,7 +1471,7 @@ class BasicAtomicUIntTests: XCTestCase {
     let v: UnsafeAtomic<UInt> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1480,7 +1480,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1489,7 +1489,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1498,7 +1498,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1512,7 +1512,7 @@ class BasicAtomicUIntTests: XCTestCase {
     let v: UnsafeAtomic<UInt> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1521,7 +1521,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1530,7 +1530,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1539,7 +1539,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1553,7 +1553,7 @@ class BasicAtomicUIntTests: XCTestCase {
     let v: UnsafeAtomic<UInt> = .create(12)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, UInt) = v.compareExchange(
+    var (exchanged, original): (Bool, UInt) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1562,7 +1562,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 12)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 12,
       desired: 23,
       successOrdering: .sequentiallyConsistent,
@@ -1571,7 +1571,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 23)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,
@@ -1580,7 +1580,7 @@ class BasicAtomicUIntTests: XCTestCase {
     XCTAssertEqual(original, 23)
     XCTAssertEqual(v.load(ordering: .relaxed), 12)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: 23,
       desired: 12,
       successOrdering: .sequentiallyConsistent,

--- a/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicUnmanagedTests.swift
+++ b/Tests/AtomicsTests/Basics/autogenerated/BasicAtomicUnmanagedTests.swift
@@ -986,7 +986,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>> = .create(_bar1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .relaxed,
@@ -995,7 +995,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar1)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .relaxed,
@@ -1004,7 +1004,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .relaxed,
@@ -1013,7 +1013,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .relaxed,
@@ -1027,7 +1027,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>> = .create(_bar1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .relaxed,
@@ -1036,7 +1036,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar1)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .relaxed,
@@ -1045,7 +1045,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .relaxed,
@@ -1054,7 +1054,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .relaxed,
@@ -1068,7 +1068,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>> = .create(_bar1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .relaxed,
@@ -1077,7 +1077,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar1)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .relaxed,
@@ -1086,7 +1086,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .relaxed,
@@ -1095,7 +1095,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .relaxed,
@@ -1109,7 +1109,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>> = .create(_bar1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .acquiring,
@@ -1118,7 +1118,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar1)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .acquiring,
@@ -1127,7 +1127,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .acquiring,
@@ -1136,7 +1136,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .acquiring,
@@ -1150,7 +1150,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>> = .create(_bar1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .acquiring,
@@ -1159,7 +1159,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar1)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .acquiring,
@@ -1168,7 +1168,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .acquiring,
@@ -1177,7 +1177,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .acquiring,
@@ -1191,7 +1191,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>> = .create(_bar1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .acquiring,
@@ -1200,7 +1200,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar1)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .acquiring,
@@ -1209,7 +1209,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .acquiring,
@@ -1218,7 +1218,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .acquiring,
@@ -1232,7 +1232,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>> = .create(_bar1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .releasing,
@@ -1241,7 +1241,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar1)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .releasing,
@@ -1250,7 +1250,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .releasing,
@@ -1259,7 +1259,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .releasing,
@@ -1273,7 +1273,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>> = .create(_bar1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .releasing,
@@ -1282,7 +1282,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar1)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .releasing,
@@ -1291,7 +1291,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .releasing,
@@ -1300,7 +1300,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .releasing,
@@ -1314,7 +1314,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>> = .create(_bar1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .releasing,
@@ -1323,7 +1323,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar1)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .releasing,
@@ -1332,7 +1332,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .releasing,
@@ -1341,7 +1341,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .releasing,
@@ -1355,7 +1355,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>> = .create(_bar1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .acquiringAndReleasing,
@@ -1364,7 +1364,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar1)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .acquiringAndReleasing,
@@ -1373,7 +1373,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .acquiringAndReleasing,
@@ -1382,7 +1382,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .acquiringAndReleasing,
@@ -1396,7 +1396,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>> = .create(_bar1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .acquiringAndReleasing,
@@ -1405,7 +1405,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar1)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .acquiringAndReleasing,
@@ -1414,7 +1414,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .acquiringAndReleasing,
@@ -1423,7 +1423,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .acquiringAndReleasing,
@@ -1437,7 +1437,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>> = .create(_bar1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .acquiringAndReleasing,
@@ -1446,7 +1446,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar1)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .acquiringAndReleasing,
@@ -1455,7 +1455,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .acquiringAndReleasing,
@@ -1464,7 +1464,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .acquiringAndReleasing,
@@ -1478,7 +1478,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>> = .create(_bar1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .sequentiallyConsistent,
@@ -1487,7 +1487,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar1)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .sequentiallyConsistent,
@@ -1496,7 +1496,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .sequentiallyConsistent,
@@ -1505,7 +1505,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .sequentiallyConsistent,
@@ -1519,7 +1519,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>> = .create(_bar1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .sequentiallyConsistent,
@@ -1528,7 +1528,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar1)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .sequentiallyConsistent,
@@ -1537,7 +1537,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .sequentiallyConsistent,
@@ -1546,7 +1546,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .sequentiallyConsistent,
@@ -1560,7 +1560,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     let v: UnsafeAtomic<Unmanaged<Bar>> = .create(_bar1)
     defer { v.destroy() }
 
-    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.compareExchange(
+    var (exchanged, original): (Bool, Unmanaged<Bar>) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .sequentiallyConsistent,
@@ -1569,7 +1569,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar1)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar1,
       desired: _bar2,
       successOrdering: .sequentiallyConsistent,
@@ -1578,7 +1578,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar2)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .sequentiallyConsistent,
@@ -1587,7 +1587,7 @@ class BasicAtomicUnmanagedTests: XCTestCase {
     XCTAssertEqual(original, _bar2)
     XCTAssertEqual(v.load(ordering: .relaxed), _bar1)
 
-    (exchanged, original) = v.compareExchange(
+    (exchanged, original) = v.weakCompareExchange(
       expected: _bar2,
       desired: _bar1,
       successOrdering: .sequentiallyConsistent,


### PR DESCRIPTION
Oops, we had two separate tests for `compareExchange` and `weakCompareExchange`, but they were both invoking `compareExchange` only.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-atomics)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [X] I've verified that my change does not break any existing tests.
- [ ] I've updated the documentation if necessary.
