### PR TITLE
Fix compatibility with Swift 5.6

### DIFF
--- a/Sources/Atomics/Primitives.shims.swift.gyb
+++ b/Sources/Atomics/Primitives.shims.swift.gyb
@@ -38,7 +38,7 @@ internal func _atomicMemoryFence(
 }
 
 % for (swiftType, builtin64, builtin32, shimType) in atomicTypes:
-extension UnsafeMutablePointer<${shimType}> {
+extension UnsafeMutablePointer where Pointee == ${shimType} {
   /// Atomically loads a word starting at this address with the specified
   /// memory ordering.
   @_semantics("atomics.requires_constant_orderings")

--- a/Sources/Atomics/autogenerated/Primitives.shims.swift
+++ b/Sources/Atomics/autogenerated/Primitives.shims.swift
@@ -42,7 +42,7 @@ internal func _atomicMemoryFence(
   }
 }
 
-extension UnsafeMutablePointer<_AtomicInt8Storage> {
+extension UnsafeMutablePointer where Pointee == _AtomicInt8Storage {
   /// Atomically loads a word starting at this address with the specified
   /// memory ordering.
   @_semantics("atomics.requires_constant_orderings")
@@ -492,7 +492,7 @@ extension UnsafeMutablePointer<_AtomicInt8Storage> {
     }
   }
 }
-extension UnsafeMutablePointer<_AtomicInt16Storage> {
+extension UnsafeMutablePointer where Pointee == _AtomicInt16Storage {
   /// Atomically loads a word starting at this address with the specified
   /// memory ordering.
   @_semantics("atomics.requires_constant_orderings")
@@ -942,7 +942,7 @@ extension UnsafeMutablePointer<_AtomicInt16Storage> {
     }
   }
 }
-extension UnsafeMutablePointer<_AtomicInt32Storage> {
+extension UnsafeMutablePointer where Pointee == _AtomicInt32Storage {
   /// Atomically loads a word starting at this address with the specified
   /// memory ordering.
   @_semantics("atomics.requires_constant_orderings")
@@ -1392,7 +1392,7 @@ extension UnsafeMutablePointer<_AtomicInt32Storage> {
     }
   }
 }
-extension UnsafeMutablePointer<_AtomicInt64Storage> {
+extension UnsafeMutablePointer where Pointee == _AtomicInt64Storage {
   /// Atomically loads a word starting at this address with the specified
   /// memory ordering.
   @_semantics("atomics.requires_constant_orderings")
@@ -1842,7 +1842,7 @@ extension UnsafeMutablePointer<_AtomicInt64Storage> {
     }
   }
 }
-extension UnsafeMutablePointer<_AtomicIntStorage> {
+extension UnsafeMutablePointer where Pointee == _AtomicIntStorage {
   /// Atomically loads a word starting at this address with the specified
   /// memory ordering.
   @_semantics("atomics.requires_constant_orderings")
@@ -2292,7 +2292,7 @@ extension UnsafeMutablePointer<_AtomicIntStorage> {
     }
   }
 }
-extension UnsafeMutablePointer<_AtomicDoubleWordStorage> {
+extension UnsafeMutablePointer where Pointee == _AtomicDoubleWordStorage {
   /// Atomically loads a word starting at this address with the specified
   /// memory ordering.
   @_semantics("atomics.requires_constant_orderings")


### PR DESCRIPTION
`extension Foo<Bar>` was not a thing in Swift 5.6.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-atomics)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [X] I've verified that my change does not break any existing tests.
- [ ] I've updated the documentation if necessary.
