### PR TITLE
Utilities/run-full-tests.sh: Use a different derived data path when building the Xcode project

### DIFF
--- a/Utilities/run-full-tests.sh
+++ b/Utilities/run-full-tests.sh
@@ -99,7 +99,7 @@ try_xcodeproj() {
         xcrun xcodebuild \
         -configuration Release \
         -destination "$destination" \
-        -derivedDataPath "$build_dir/xcodebuild" \
+        -derivedDataPath "$build_dir/xcodeproj" \
         "$@"
 }
 


### PR DESCRIPTION

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-atomics)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [X] I've verified that my change does not break any existing tests.
- [ ] I've updated the documentation if necessary.
