### PR TITLE
Fix reference doc variable references

### DIFF
--- a/Sources/Atomics/AtomicLazyReference.swift.gyb
+++ b/Sources/Atomics/AtomicLazyReference.swift.gyb
@@ -179,16 +179,16 @@ extension ${type} {
   ///
   /// ```
   /// class Image {
-  ///   var _histogram: UnsafeAtomicLazyReference<Histogram> = ...
+  ///   var _histogram: UnsafeAtomicLazyReference<Histogram> = .init()
   ///
   ///   // This is safe to call concurrently from multiple threads.
   ///   var atomicLazyHistogram: Histogram {
-  ///     if let histogram = _histogram.load() { return foo }
+  ///     if let histogram = _histogram.load() { return histogram }
   ///     // Note that code here may run concurrently on
   ///     // multiple threads, but only one of them will get to
   ///     // succeed setting the reference.
   ///     let histogram = ...
-  ///     return _histogram.storeIfNilThenLoad(foo)
+  ///     return _histogram.storeIfNilThenLoad(histogram)
   /// }
   /// ```
   ///


### PR DESCRIPTION
Fix reference doc variable references

<!-- Thanks for contributing to Swift Atomics! -->

<!-- If this pull request adds new API, please add '?template=new.md'
     to the URL to switch to the appropriate template. -->

<!-- Please add a description of your changes and rationale. Provide
     links to an existing issue or external references/discussions, if
     appropriate. -->

This PR fixes the code samples for atomic lazy reference types.
     
<!-- Complete the steps in the checklist by placing an 'x' in each box:
    - [x] I've completed this task
    - [ ] This task isn't completed
-->


### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-atomics)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've verified that my change does not break any existing tests.
- [x] I've updated the documentation if necessary.
