### PR TITLE
[_AtomicShims] On Darwin, call swift_retain_n/swift_release_n via dlsym

### DIFF
--- a/Sources/_AtomicsShims/src/_AtomicsShims.c
+++ b/Sources/_AtomicsShims/src/_AtomicsShims.c
@@ -12,9 +12,51 @@
 
 #include "_AtomicsShims.h"
 
-// FIXME: These should be static inline header-only shims, but Swift 5.3 doesn't
-// like calls to swift_retain_n/swift_release_n appearing in Swift code, not
-// even when imported through C. (See https://bugs.swift.org/browse/SR-13708)
+// FIXME: _sa_retain_n and _sa_release_n should be static inline header-only
+// shims, but Swift 5.3 doesn't like calls to swift_retain_n/swift_release_n
+// appearing in Swift code, not even when imported through C.
+// (See https://github.com/apple/swift/issues/56105)
+//
+// Additionally, on Apple platforms we use dlopen/dlsym to avoid linkage issues
+// when this shims module is built as a standalone dylib, which happens
+// sometimes with the Xcode integration. There is no good way for a package to
+// declare that one of its C modules has to link with the Swift runtime, so
+// the module fails to link when built as a standalone library.
+// (See https://github.com/apple/swift-atomics/issues/55)
+
+#if defined(__APPLE__) && defined(__MACH__)
+#include <stdlib.h>
+#include <dlfcn.h>
+#include <dispatch/dispatch.h>
+
+static dispatch_once_t init_token;
+static void *(*swift_retain_n)(void *, uint32_t);
+static void *(*swift_release_n)(void *, uint32_t);
+
+static void _sa_initialize(void *context)
+{
+  void *handle = dlopen("/usr/lib/swift/libswiftCore.dylib",
+                        RTLD_LAZY | RTLD_GLOBAL | RTLD_NOLOAD);
+  if (handle == NULL) {
+    abort();
+  }
+  swift_retain_n = dlsym(handle, "swift_retain_n");
+  swift_release_n = dlsym(handle, "swift_release_n");
+}
+
+void _sa_retain_n(void *object, uint32_t n)
+{
+  dispatch_once_f(&init_token, NULL, _sa_initialize);
+  swift_retain_n(object, n);
+}
+
+void _sa_release_n(void *object, uint32_t n)
+{
+  dispatch_once_f(&init_token, NULL, _sa_initialize);
+  swift_release_n(object, n);
+}
+
+#else // !(defined(__APPLE__) && defined(__MACH__))
 
 void _sa_retain_n(void *object, uint32_t n)
 {
@@ -27,3 +69,4 @@ void _sa_release_n(void *object, uint32_t n)
   extern void swift_release_n(void *object, uint32_t n);
   swift_release_n(object, n);
 }
+#endif // defined(__APPLE__) && defined(__MACH__)


### PR DESCRIPTION
This avoids a linker failure when the build system decides to build this module as a standalone library.

Hopefully this will all go away soon, when swift_retain_n/swift_release_n will become primitives exposed by the stdlib.

rdar://108390931

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-atomics)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [X] I've verified that my change does not break any existing tests.
- [ ] I've updated the documentation if necessary.
