### PR TITLE
[_AtomicShims] On Darwin, call swift_retain_n/swift_release_n via inline assembly

### DIFF
--- a/Sources/_AtomicsShims/include/_AtomicsShims.h
+++ b/Sources/_AtomicsShims/include/_AtomicsShims.h
@@ -236,8 +236,62 @@ SWIFTATOMIC_DEFINE_TYPE(DoubleWord, _sa_dword)
 
 #endif //!defined(ATOMICS_NATIVE_BUILTINS) && defined(__swift__)
 
+#if defined(__APPLE__) && defined(__MACH__)
+
+SWIFTATOMIC_INLINE
+void _sa_retain_n(void *object, uint32_t n) {
+#if defined(__aarch64__)
+  register void *x0 asm ("x0") = object;
+  register uint32_t x1 asm ("x1") = n;
+  asm volatile (
+                "bl _swift_retain_n\n"
+                :: "r" (x0), "r" (x1)
+                : "memory", /*"x0", "x1",*/ "x2", "x3", "x4", "x5", "x6", "x7", "x8"
+                );
+#elif defined(__x86_64__)
+  asm volatile (
+                "call _swift_retain_n\n"
+                :: "D" (object), "S" (n)
+                : "memory", "rax", /*"rdi", "rsi",*/ "rbx", "rcx", "r8", "r9", "r10", "r11"
+                );
+#elif defined(__arm__)
+#  error FIXME
+#elif defined(__i386__)
+#  error FIXME
+#else
+#  error Unsupported target architecture
+#endif
+}
+
+SWIFTATOMIC_INLINE
+void _sa_release_n(void *object, uint32_t n) {
+#if defined(__aarch64__)
+  register void *x0 asm ("x0") = object;
+  register uint32_t x1 asm ("x1") = n;
+  asm volatile (
+                "bl _swift_release_n\n"
+                :: "r" (x0), "r" (x1)
+                : "memory", /*"x0", "x1",*/ "x2", "x3", "x4", "x5", "x6", "x7", "x8"
+                );
+#elif defined(__x86_64__)
+  asm volatile (
+                "call _swift_release_n\n"
+                :: "D" (object), "S" (n)
+                : "memory", "rax", /*"rdi", "rsi",*/ "rbx", "rcx", "r8", "r9", "r10", "r11"
+                );
+#elif defined(__arm__)
+#  error FIXME
+#elif defined(__i386__)
+#  error FIXME
+#else
+#  error Unsupported target architecture
+#endif
+}
+
+#else
 SWIFTATOMIC_SWIFTCC SWIFTATOMIC_SHIMS_EXPORT void _sa_retain_n(void *object, uint32_t n);
 SWIFTATOMIC_SWIFTCC SWIFTATOMIC_SHIMS_EXPORT void _sa_release_n(void *object, uint32_t n);
+#endif
 
 #endif // __cplusplus
 #endif //SWIFTATOMIC_HEADER_INCLUDED

--- a/Sources/_AtomicsShims/src/_AtomicsShims.c
+++ b/Sources/_AtomicsShims/src/_AtomicsShims.c
@@ -12,10 +12,19 @@
 
 #include "_AtomicsShims.h"
 
-// FIXME: These should be static inline header-only shims, but Swift 5.3 doesn't
-// like calls to swift_retain_n/swift_release_n appearing in Swift code, not
-// even when imported through C. (See https://bugs.swift.org/browse/SR-13708)
+// FIXME: _sa_retain_n and _sa_release_n should be static inline header-only
+// shims, but Swift 5.3 doesn't like calls to swift_retain_n/swift_release_n
+// appearing in Swift code, not even when imported through C.
+// (See https://github.com/apple/swift/issues/56105)
+//
+// Additionally, on Apple platforms we use dlopen/dlsym to avoid linkage issues
+// when this shims module is built as a standalone dylib, which happens
+// sometimes with the Xcode integration. There is no good way for a package to
+// declare that one of its C modules has to link with the Swift runtime, so
+// the module fails to link when built as a standalone library.
+// (See https://github.com/apple/swift-atomics/issues/55)
 
+#if !(defined(__APPLE__) && defined(__MACH__))
 void _sa_retain_n(void *object, uint32_t n)
 {
   extern void *swift_retain_n(void *object, uint32_t n);
@@ -27,3 +36,4 @@ void _sa_release_n(void *object, uint32_t n)
   extern void swift_release_n(void *object, uint32_t n);
   swift_release_n(object, n);
 }
+#endif // defined(__APPLE__) && defined(__MACH__)


### PR DESCRIPTION
This is an alternative to #95, using another, far more fascinating, way to attempt to resolve #55. It uses the C header smuggle a call to swift_retain_n/swift_release_n behind the back of the Swift ARC optimizer using inline assembly.

(This draft generates procedure calls; it would probably be better to jump directly into the runtime.)

Resolves #55.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-atomics)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've verified that my change does not break any existing tests.
- [ ] I've updated the documentation if necessary.
