### PR TITLE
[_AtomicShims] On Darwin, ensure we link against libswiftCore using assembly shenanigans

### DIFF
--- a/Sources/_AtomicsShims/src/_AtomicsShims.c
+++ b/Sources/_AtomicsShims/src/_AtomicsShims.c
@@ -20,7 +20,6 @@
 // Ensure we link with libswiftCore.dylib even when the build system decides
 // to build this module as a standalone library.
 // (See https://github.com/apple/swift-atomics/issues/55)
-__asm__(".linker_option \"-L/usr/lib/swift\"\n");
 __asm__(".linker_option \"-lswiftCore\"\n");
 #endif
 

--- a/Sources/_AtomicsShims/src/_AtomicsShims.c
+++ b/Sources/_AtomicsShims/src/_AtomicsShims.c
@@ -16,6 +16,14 @@
 // like calls to swift_retain_n/swift_release_n appearing in Swift code, not
 // even when imported through C. (See https://bugs.swift.org/browse/SR-13708)
 
+#if defined(__APPLE__) && defined(__MACH__)
+// Ensure we link with libswiftCore.dylib even when the build system decides
+// to build this module as a standalone library.
+// (See https://github.com/apple/swift-atomics/issues/55)
+__asm__(".linker_option \"-L/usr/lib/swift\"\n");
+__asm__(".linker_option \"-lswiftCore\"\n");
+#endif
+
 void _sa_retain_n(void *object, uint32_t n)
 {
   extern void *swift_retain_n(void *object, uint32_t n);


### PR DESCRIPTION
Like #95 and #96, the intention here is to avoid a linker failure when the build system decides to build this module as a standalone library.

Hopefully this will all go away soon, when swift_retain_n/swift_release_n will become primitives exposed by the stdlib.

Resolves #55 

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-atomics)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [X] I've verified that my change does not break any existing tests.
- [ ] I've updated the documentation if necessary.
