### PR TITLE
[native] Stop using @_implementationOnly import in package configs

### DIFF
--- a/Sources/Atomics/Unmanaged extensions.swift
+++ b/Sources/Atomics/Unmanaged extensions.swift
@@ -21,7 +21,7 @@ internal func _sa_release_n(_ object: UnsafeMutableRawPointer, _ delta: UInt32)
 // import of the shims module, and we only need it to get the declarations for
 // _sa_retain_n/_sa_release_n. The import is unfortunately still problematic;
 // these functions need to be moved into the stdlib or (preferably) we need
-// a compiler-level fix for https://bugs.swift.org/browse/SR-13708 to get rid
+// a compiler-level fix for https://github.com/apple/swift/issues/56105 to get rid
 // of it.
 //
 // Hiding the import using @_implementationOnly is not possible unless

--- a/Sources/Atomics/Unmanaged extensions.swift
+++ b/Sources/Atomics/Unmanaged extensions.swift
@@ -16,9 +16,17 @@ internal func _sa_retain_n(_ object: UnsafeMutableRawPointer, _ delta: UInt32)
 
 @_silgen_name("_sa_release_n")
 internal func _sa_release_n(_ object: UnsafeMutableRawPointer, _ delta: UInt32)
-#elseif ATOMICS_NATIVE_BUILTINS
-@_implementationOnly import _AtomicsShims
 #else
+// Note: with ATOMICS_NATIVE_BUILTINS, this file contains the last remaining
+// import of the shims module, and we only need it to get the declarations for
+// _sa_retain_n/_sa_release_n. The import is unfortunately still problematic;
+// these functions need to be moved into the stdlib or (preferably) we need
+// a compiler-level fix for https://bugs.swift.org/browse/SR-13708 to get rid
+// of it.
+//
+// Hiding the import using @_implementationOnly is not possible unless
+// Swift's library evolution dialect is enabled. (Which we cannot easily test
+// here.) Perhaps `internal import` will help work around this at some point.
 import _AtomicsShims
 #endif
 


### PR DESCRIPTION
@_implementationOnly does not work correctly unless Swift’s Library Evolution dialect is enabled — it leads to obscure module loading failures.

There seems to be no way to create a compile-time condition on whether library evolution is enabled, so we need to stop using @_implementationOnly imports in all package configurations.

Resolves #107.

### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-atomics)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [X] I've verified that my change does not break any existing tests.
- [ ] I've updated the documentation if necessary.
