### PR TITLE
Make AtomicsShims compatible with C++ interop

### DIFF
--- a/Sources/_AtomicsShims/include/_AtomicsShims.h
+++ b/Sources/_AtomicsShims/include/_AtomicsShims.h
@@ -34,7 +34,11 @@
 #    define SWIFTATOMIC_SHIMS_EXPORT
 #  endif
 #else
-#  define SWIFTATOMIC_SHIMS_EXPORT extern
+#  ifdef __cplusplus
+#    define SWIFTATOMIC_SHIMS_EXPORT extern "C"
+#  else
+#    define SWIFTATOMIC_SHIMS_EXPORT extern
+#  endif
 #endif
 
 // Swift-importable shims for C atomics.


### PR DESCRIPTION
This fixes linker errors such as
```
Undefined symbols for architecture arm64:
  "_sa_retain_n(void*, unsigned int)", referenced from:
      (extension in Atomics):Swift.Unmanaged.retain(by: Swift.Int) -> () in Unmanaged extensions.swift.o
   NOTE: found '__sa_retain_n' in _AtomicsShims.c.o, declaration possibly missing 'extern "C"'
```
when building with Swift/C++ interoperability enabled.

<!-- Thanks for contributing to Swift Atomics! -->

<!-- If this pull request adds new API, please add '?template=new.md'
     to the URL to switch to the appropriate template. -->

<!-- Please add a description of your changes and rationale. Provide
     links to an existing issue or external references/discussions, if
     appropriate. -->
     
<!-- Complete the steps in the checklist by placing an 'x' in each box:
    - [x] I've completed this task
    - [ ] This task isn't completed
-->


### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-atomics)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [x] I've verified that my change does not break any existing tests.
- [ ] I've updated the documentation if necessary.
