### PR TITLE
Fix API documentation links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,16 +124,16 @@ Requiring a new Swift release will only require a minor version bump.
 
 For a detailed overview of the interfaces offered by this package, please see [our API documentation][APIDocs].
 
-[APIDocs]: https://swiftpackageindex.com/apple/swift-atomics/1.2.0/documentation/atomics
-[AtomicValue]: https://swiftpackageindex.com/apple/swift-atomics/1.2.0/documentation/atomics/atomicvalue
-[DoubleWord]: https://swiftpackageindex.com/apple/swift-atomics/1.2.0/documentation/atomics/doubleword
-[AtomicReference]: https://swiftpackageindex.com/apple/swift-atomics/1.2.0/documentation/atomics/atomicreference
-[UnsafeAtomic]: https://swiftpackageindex.com/apple/swift-atomics/1.2.0/documentation/atomics/unsafeatomic
-[ManagedAtomic]: https://swiftpackageindex.com/apple/swift-atomics/1.2.0/documentation/atomics/managedatomic
-[ManagedAtomicLazyReference]: https://swiftpackageindex.com/apple/swift-atomics/1.2.0/documentation/atomics/managedatomiclazyreference
-[UnsafeAtomicLazyReference]: https://swiftpackageindex.com/apple/swift-atomics/1.2.0/documentation/atomics/unsafeatomiclazyreference
-[AtomicStorage]: https://swiftpackageindex.com/apple/swift-atomics/1.2.0/documentation/atomics/atomicstorage
-[AtomicInteger]: https://swiftpackageindex.com/apple/swift-atomics/1.2.0/documentation/atomics/atomicinteger
+[APIDocs]: https://swiftpackageindex.com/apple/swift-atomics//documentation/atomics
+[AtomicValue]: https://swiftpackageindex.com/apple/swift-atomics/documentation/atomics/atomicvalue
+[DoubleWord]: https://swiftpackageindex.com/apple/swift-atomics/documentation/atomics/doubleword
+[AtomicReference]: https://swiftpackageindex.com/apple/swift-atomics/documentation/atomics/atomicreference
+[UnsafeAtomic]: https://swiftpackageindex.com/apple/swift-atomics/documentation/atomics/unsafeatomic
+[ManagedAtomic]: https://swiftpackageindex.com/apple/swift-atomics/documentation/atomics/managedatomic
+[ManagedAtomicLazyReference]: https://swiftpackageindex.com/apple/swift-atomics/documentation/atomics/managedatomiclazyreference
+[UnsafeAtomicLazyReference]: https://swiftpackageindex.com/apple/swift-atomics/documentation/atomics/unsafeatomiclazyreference
+[AtomicStorage]: https://swiftpackageindex.com/apple/swift-atomics/documentation/atomics/atomicstorage
+[AtomicInteger]: https://swiftpackageindex.com/apple/swift-atomics/documentation/atomics/atomicinteger
 
 The package implements atomic operations for the following Swift constructs, all of which conform to the public [`AtomicValue` protocol][AtomicValue]:
 


### PR DESCRIPTION
As of today the latest public release is 1.3.0 so API docs links in README.md are outdated.
To avoid the maintenance cost of keeping URLs up to date this PR removes library version from URLs, making them always point to the latest stable release instead. 

Another alternative would be to point URLs to the main branch ([example](https://swiftpackageindex.com/apple/swift-atomics/main/documentation/atomics)), however for most of developers this README.md is the main entry point when installing the library and they would except to see docs for the latest stable release.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-atomics)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [ ] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've verified that my change does not break any existing tests.
- [ ] I've updated the documentation if necessary.
