### PR TITLE
Add `enable_wasm_sdk_build: true` to `pull_request.yml`

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,6 +11,7 @@ jobs:
     with:
       linux_exclude_swift_versions: '[{"swift_version": "5.8"}, {"swift_version": "5.9"}]'
       windows_exclude_swift_versions: '[{"swift_version": "5.9"}]'
+      enable_wasm_sdk_build: true
 
   soundness:
     name: Soundness


### PR DESCRIPTION
`swift-atomics` should be built for Wasm as one of the officially supported platforms on CI to prevent possible future regressions.

### Checklist
- [x] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-atomics)
- [x] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [x] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [x] I've verified that my change does not break any existing tests.
- [N/A] I've updated the documentation if necessary.
