### PR TITLE
Rename internal `passRetained` helper to `_passRetained`

### DIFF
--- a/Sources/Atomics/Protocols/AtomicReference.swift
+++ b/Sources/Atomics/Protocols/AtomicReference.swift
@@ -148,7 +148,7 @@ internal struct _AtomicReferenceStorage {
   @usableFromInline
   internal init(_ value: __owned AnyObject?) {
     let dword = DoubleWord(
-      _raw: Unmanaged.passRetained(value)?.toOpaque(),
+      _raw: Unmanaged._passRetained(value)?.toOpaque(),
       readers: 0,
       version: 0)
     _storage = Storage(dword)
@@ -302,7 +302,7 @@ internal struct _AtomicReferenceStorage {
     _ desired: __owned AnyObject?,
     at pointer: UnsafeMutablePointer<Self>
   ) -> AnyObject? {
-    let new = Unmanaged.passRetained(desired)
+    let new = Unmanaged._passRetained(desired)
     var old = _startLoading(from: pointer)
     var (exchanged, original) = _tryExchange(old: &old, new: new, at: pointer)
     while !exchanged {
@@ -318,7 +318,7 @@ internal struct _AtomicReferenceStorage {
     at pointer: UnsafeMutablePointer<Self>
   ) -> (exchanged: Bool, original: AnyObject?) {
     let expectedRaw = expected._raw
-    let new = Unmanaged.passRetained(desired)
+    let new = Unmanaged._passRetained(desired)
     var old = _startLoading(from: pointer)
     while old._raw == expectedRaw {
       let (exchanged, original) = _tryExchange(old: &old, new: new, at: pointer)

--- a/Sources/Atomics/Unmanaged extensions.swift
+++ b/Sources/Atomics/Unmanaged extensions.swift
@@ -42,7 +42,7 @@ extension Unmanaged {
 
 extension Unmanaged {
   @inline(__always)
-  internal static func passRetained(_ instance: __owned Instance?) -> Self? {
+  internal static func _passRetained(_ instance: __owned Instance?) -> Self? {
     guard let instance = instance else { return nil }
     return .passRetained(instance)
   }


### PR DESCRIPTION
This avoids ambiguity with a public version of the same API that is part of a Swift standard library and returns a non-optional result.

<!-- Thanks for contributing to Swift Atomics! -->

<!-- If this pull request adds new API, please add '?template=new.md'
     to the URL to switch to the appropriate template. -->

<!-- Please add a description of your changes and rationale. Provide
     links to an existing issue or external references/discussions, if
     appropriate. -->
     
<!-- Complete the steps in the checklist by placing an 'x' in each box:
    - [x] I've completed this task
    - [ ] This task isn't completed
-->


### Checklist
- [X] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-atomics)
- [X] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [X] I've followed the coding style of the rest of the project.
- [X] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [X] I've verified that my change does not break any existing tests.
- [X] I've updated the documentation if necessary.


Resolves: rdar://180441772