### PR TITLE
Fix run-full-tests.sh to fail on any failing step

### DIFF
--- a/Utilities/run-full-tests.sh
+++ b/Utilities/run-full-tests.sh
@@ -46,6 +46,7 @@ report_failure() {
 }
 
 _count=0
+failures=0
 try() {
     label="$1"
     shift
@@ -62,6 +63,7 @@ try() {
         echo "  ${red_on}${bold_on}Failed in $(($end - $start))s.${bold_off}${red_off}" \
              "${red_on}See $output for full console output.${red_off}"
         tail -10 "$output" | sed 's/^/  /'
+        failures=$(($failures + 1))
     fi
 }
 
@@ -189,4 +191,9 @@ else
         --sanitize=thread \
         -Xswiftc -DSWIFT_ATOMICS_LONG_TESTS \
         --build-path "$build_dir/spm.release.test.long+tsan"
+fi
+
+if [ "$failures" -ne 0 ]; then
+    echo "${red_on}${bold_on}Completed with $failures failing test configuration(s).${bold_off}${red_off}"
+    exit 1
 fi


### PR DESCRIPTION
## Summary
- Track failures in `Utilities/run-full-tests.sh` across all `try` invocations.
- Increment the failure counter when any build or test step exits non-zero.
- Exit with status 1 at the end if any step failed, while preserving the existing per-step log output.

## Why
The script previously printed failure output but still exited successfully because failures were not accumulated or propagated. That could hide a broken build or test configuration from CI and automation.

## Notes
This only changes final failure propagation and summary reporting; it does not change the build or test commands themselves.
