### PR TITLE
Fix single-module shim macro handling

### DIFF
--- a/Sources/_AtomicsShims/include/_AtomicsShims.h
+++ b/Sources/_AtomicsShims/include/_AtomicsShims.h
@@ -27,6 +27,12 @@
 #  define SWIFTATOMIC_SWIFTCC
 #endif
 
+#if defined(SWIFTATOMIC_SINGLE_MODULE) && !defined(ATOMICS_SINGLE_MODULE)
+#  define ATOMICS_SINGLE_MODULE SWIFTATOMIC_SINGLE_MODULE
+#elif defined(ATOMICS_SINGLE_MODULE) && !defined(SWIFTATOMIC_SINGLE_MODULE)
+#  define SWIFTATOMIC_SINGLE_MODULE ATOMICS_SINGLE_MODULE
+#endif
+
 #if ATOMICS_SINGLE_MODULE
 #  if __has_attribute(visibility) && !defined(__MINGW32__) && !defined(__CYGWIN__) && !defined(_WIN32)
 #    define SWIFTATOMIC_SHIMS_EXPORT __attribute__((visibility("hidden")))
@@ -41,7 +47,7 @@
 #  endif
 #endif
 
-#if SWIFTATOMIC_SINGLE_MODULE
+#if ATOMICS_SINGLE_MODULE
 // In the single-module configuration, declare _sa_retain_n/_sa_release_n with
 // the Swift calling convention, so that they can be easily picked up with
 // @_silgen_name'd declarations.

--- a/Utilities/run-full-tests.sh
+++ b/Utilities/run-full-tests.sh
@@ -156,6 +156,7 @@ if [ "$(uname)" = "Darwin" ]; then
     try_xcodebuild "xcodebuild.test.watchOS-simulator" "platform=watchOS Simulator,name=Apple Watch Series 6 (44mm)" test
     try_xcodebuild "xcodebuild.test.tvOS-simulator" "platform=tvOS Simulator,name=Apple TV 4K (at 1080p)" test
 
+    try_xcodeproj "xcodeproj.single-module.smoke" "platform=macOS" -project Xcode/Atomics.xcodeproj -scheme Atomics test -only-testing:AtomicsTests/BasicAtomicUnmanagedTests/test_create_destroy
     try_xcodeproj "xcodeproj.test.macOS" "platform=macOS" -project Xcode/Atomics.xcodeproj -scheme Atomics test
 fi
 


### PR DESCRIPTION
## Summary
- Normalize `ATOMICS_SINGLE_MODULE` and `SWIFTATOMIC_SINGLE_MODULE` at the top of `_AtomicsShims.h` before either macro is used.
- Use `ATOMICS_SINGLE_MODULE` for the single-module `_sa_retain_n` and `_sa_release_n` declarations, matching the Xcode and Swift configuration name.
- Add a focused Xcode project smoke step that exercises the unmanaged reference path under the `Atomics.xcodeproj` scheme.

## Why
Xcode defines `ATOMICS_SINGLE_MODULE`, and Swift checks `ATOMICS_SINGLE_MODULE`, but `_AtomicsShims.h` checked `SWIFTATOMIC_SINGLE_MODULE` for the calling-convention branch. That means the intended single-module declaration path could be skipped even though the rest of the Xcode build was in single-module mode.

## Notes
The smoke step uses `Xcode/Atomics.xcodeproj`, since that is the project configuration that defines `ATOMICS_SINGLE_MODULE` through `Xcode/Shared.xcconfig`.
