### PR TITLE
Deinitialize lazy reference storage on destroy

### DIFF
--- a/Sources/Atomics/Types/UnsafeAtomicLazyReference.swift
+++ b/Sources/Atomics/Types/UnsafeAtomicLazyReference.swift
@@ -113,8 +113,10 @@ extension UnsafeAtomicLazyReference {
     // `Storage` is layout-compatible with its only stored property.
     let address = UnsafeMutableRawPointer(_ptr)
       .assumingMemoryBound(to: Storage.self)
-    defer { address.deallocate() }
-    return address.pointee.dispose()
+    let result = address.pointee.dispose()
+    address.deinitialize(count: 1)
+    address.deallocate()
+    return result
   }
 }
 


### PR DESCRIPTION
## Summary
- Update `UnsafeAtomicLazyReference.destroy()` to deinitialize its storage before deallocating it.
- Preserve the existing `dispose()` behavior and returned final value.

## Why
`UnsafeAtomic.destroy()` disposes, deinitializes, and then deallocates its storage. `UnsafeAtomicLazyReference.destroy()` already disposed and deallocated, but skipped the matching deinitialization step.

## Notes
This keeps the storage lifecycle consistent with the documented destroy behavior and the regular unsafe atomic implementation.
