### PR TITLE
Fix Bool then-load return value docs

### DIFF
--- a/Sources/Atomics/Conformances/AtomicBool.swift.gyb
+++ b/Sources/Atomics/Conformances/AtomicBool.swift.gyb
@@ -211,12 +211,12 @@ extension ${construct} where Value == Bool {
 
 extension ${construct} where Value == Bool {
 % for (name, iname, op, label, doc) in boolOperations:
-  /// Perform an atomic ${doc} operation and return the original value, applying
+  /// Perform an atomic ${doc} operation and return the resulting value, applying
   /// the specified memory ordering.
   ///
   /// - Parameter operand: A boolean value.
   /// - Parameter ordering: The memory ordering to apply on this operation.
-  /// - Returns: The original value before the operation.
+  /// - Returns: The value after the operation.
   @_semantics("atomics.requires_constant_orderings")
   @_transparent @_alwaysEmitIntoClient
   public func ${lowerFirst(name)}ThenLoad(

--- a/Sources/Atomics/Conformances/autogenerated/AtomicBool.swift
+++ b/Sources/Atomics/Conformances/autogenerated/AtomicBool.swift
@@ -281,12 +281,12 @@ extension UnsafeAtomic where Value == Bool {
 }
 
 extension UnsafeAtomic where Value == Bool {
-  /// Perform an atomic logical AND operation and return the original value, applying
+  /// Perform an atomic logical AND operation and return the resulting value, applying
   /// the specified memory ordering.
   ///
   /// - Parameter operand: A boolean value.
   /// - Parameter ordering: The memory ordering to apply on this operation.
-  /// - Returns: The original value before the operation.
+  /// - Returns: The value after the operation.
   @_semantics("atomics.requires_constant_orderings")
   @_transparent @_alwaysEmitIntoClient
   public func logicalAndThenLoad(
@@ -300,12 +300,12 @@ extension UnsafeAtomic where Value == Bool {
     return original && operand
   }
 
-  /// Perform an atomic logical OR operation and return the original value, applying
+  /// Perform an atomic logical OR operation and return the resulting value, applying
   /// the specified memory ordering.
   ///
   /// - Parameter operand: A boolean value.
   /// - Parameter ordering: The memory ordering to apply on this operation.
-  /// - Returns: The original value before the operation.
+  /// - Returns: The value after the operation.
   @_semantics("atomics.requires_constant_orderings")
   @_transparent @_alwaysEmitIntoClient
   public func logicalOrThenLoad(
@@ -319,12 +319,12 @@ extension UnsafeAtomic where Value == Bool {
     return original || operand
   }
 
-  /// Perform an atomic logical XOR operation and return the original value, applying
+  /// Perform an atomic logical XOR operation and return the resulting value, applying
   /// the specified memory ordering.
   ///
   /// - Parameter operand: A boolean value.
   /// - Parameter ordering: The memory ordering to apply on this operation.
-  /// - Returns: The original value before the operation.
+  /// - Returns: The value after the operation.
   @_semantics("atomics.requires_constant_orderings")
   @_transparent @_alwaysEmitIntoClient
   public func logicalXorThenLoad(
@@ -394,12 +394,12 @@ extension ManagedAtomic where Value == Bool {
 }
 
 extension ManagedAtomic where Value == Bool {
-  /// Perform an atomic logical AND operation and return the original value, applying
+  /// Perform an atomic logical AND operation and return the resulting value, applying
   /// the specified memory ordering.
   ///
   /// - Parameter operand: A boolean value.
   /// - Parameter ordering: The memory ordering to apply on this operation.
-  /// - Returns: The original value before the operation.
+  /// - Returns: The value after the operation.
   @_semantics("atomics.requires_constant_orderings")
   @_transparent @_alwaysEmitIntoClient
   public func logicalAndThenLoad(
@@ -413,12 +413,12 @@ extension ManagedAtomic where Value == Bool {
     return original && operand
   }
 
-  /// Perform an atomic logical OR operation and return the original value, applying
+  /// Perform an atomic logical OR operation and return the resulting value, applying
   /// the specified memory ordering.
   ///
   /// - Parameter operand: A boolean value.
   /// - Parameter ordering: The memory ordering to apply on this operation.
-  /// - Returns: The original value before the operation.
+  /// - Returns: The value after the operation.
   @_semantics("atomics.requires_constant_orderings")
   @_transparent @_alwaysEmitIntoClient
   public func logicalOrThenLoad(
@@ -432,12 +432,12 @@ extension ManagedAtomic where Value == Bool {
     return original || operand
   }
 
-  /// Perform an atomic logical XOR operation and return the original value, applying
+  /// Perform an atomic logical XOR operation and return the resulting value, applying
   /// the specified memory ordering.
   ///
   /// - Parameter operand: A boolean value.
   /// - Parameter ordering: The memory ordering to apply on this operation.
-  /// - Returns: The original value before the operation.
+  /// - Returns: The value after the operation.
   @_semantics("atomics.requires_constant_orderings")
   @_transparent @_alwaysEmitIntoClient
   public func logicalXorThenLoad(


### PR DESCRIPTION
## Summary
- Fix `Bool` `logical*ThenLoad` docs to say they return the resulting value, not the original value.
- Update the `.gyb` source and regenerate `Sources/Atomics/Conformances/autogenerated/AtomicBool.swift`.

## Why
`logicalAndThenLoad`, `logicalOrThenLoad`, and `logicalXorThenLoad` compute the new value after applying the logical operation and return that value. The existing docs described the return value as the original value, which matches `loadThenLogical*` but not the `*ThenLoad` APIs.

## Notes
This is documentation-only; the implementations already return the resulting value.
